### PR TITLE
Add Atom feed autodiscovery

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -122,6 +122,9 @@
       <link rel="stylesheet" href="{{ get_url(path='main.css') | safe }}">
       <link rel="stylesheet" href="{{ get_url(path='custom.css') | safe }}">
     {% endblock styles %}
+    {% block rss %}
+      <link rel="alternate" type="application/atom+xml" href="{{ get_url(path='atom.xml') | safe }}" title="Atom Feed">
+    {% endblock rss %}
     {% block posthead %}{% endblock posthead %}
   </head>
   <body>


### PR DESCRIPTION
So that it is possible to get the Atom feed by just pasting the homepage in your feed reader. Fixes
https://github.com/Chemaclass/chemaclass.com/issues/2, previously proposed