### PR TITLE
Add scroll to top button

### DIFF
--- a/sass/custom.scss
+++ b/sass/custom.scss
@@ -496,6 +496,10 @@ a.tooltip:hover {
     transform: translateY(0);
     transition: transform 0.5s ease-in;
   }
+
+  @media (min-width: 880px) {
+    right: calc((100vw - 700px) / 2); /* Keep button inside the <main> tag */
+  }
 }
 
 .only-desktop-visible, .only-phone-visible {

--- a/sass/custom.scss
+++ b/sass/custom.scss
@@ -474,6 +474,30 @@ a.tooltip:hover {
   }
 }
 
+#scroll-to-top {
+  position: fixed;
+  bottom: 1rem;
+  right: 1rem;
+  z-index: 1000;
+  border-radius: 9999px;
+  border: 2px solid var(--body-color);
+  width: 30px;
+  height: 30px;
+  display: grid;
+  place-items: center;
+  cursor: pointer;
+  background-color: var(--body-bg);
+
+  &.hidden {
+    transform: translateY(150%);
+    transition: transform 0.5s ease-out;
+  }
+  &.show {
+    transform: translateY(0);
+    transition: transform 0.5s ease-in;
+  }
+}
+
 .only-desktop-visible, .only-phone-visible {
   display: none;
 }

--- a/sass/custom.scss
+++ b/sass/custom.scss
@@ -476,8 +476,8 @@ a.tooltip:hover {
 
 #scroll-to-top {
   position: fixed;
-  bottom: 1rem;
-  right: 1rem;
+  bottom: 4px;
+  right: 8px;
   z-index: 1000;
   border-radius: 9999px;
   border: 2px solid var(--body-color);
@@ -498,7 +498,7 @@ a.tooltip:hover {
   }
 
   @media (min-width: 880px) {
-    right: calc((100vw - 700px) / 2); /* Keep button inside the <main> tag */
+    right: calc((100vw - 700px) / 2 - 34px); /* Keep button closes to the <main> tag */
   }
 }
 

--- a/static/scroll-to-top.js
+++ b/static/scroll-to-top.js
@@ -22,7 +22,7 @@ window.addEventListener('load', function () {
         }
 
         lastScrollY = currentScrollY;
-    }, 50));
+    }, 100));
 
     $scrollToTop.addEventListener('click', () => {
         window.scrollTo({top: 0, behavior: 'smooth'});

--- a/static/scroll-to-top.js
+++ b/static/scroll-to-top.js
@@ -1,0 +1,30 @@
+window.addEventListener('load', function () {
+    const $scrollToTop = document.getElementById('scroll-to-top');
+    const $postTitle = document.querySelector('.post-title');
+
+    if (!$postTitle) {
+        $scrollToTop.classList.add('hidden');
+        return;
+    }
+
+    let lastScrollY = window.scrollY;
+    const topMargin = 80; // Always show the navbar within px of the top
+
+    // TODO: Extract `debounce` implementation to shared module or something
+    window.addEventListener('scroll', debounce(() => {
+        const currentScrollY = window.scrollY;
+        if (currentScrollY >= topMargin) {
+            $scrollToTop.classList.remove('hidden');
+            $scrollToTop.classList.add('show');
+        } else {
+            $scrollToTop.classList.remove('show');
+            $scrollToTop.classList.add('hidden');
+        }
+
+        lastScrollY = currentScrollY;
+    }, 50));
+
+    $scrollToTop.addEventListener('click', () => {
+        window.scrollTo({top: 0, behavior: 'smooth'});
+    });
+});

--- a/static/scroll-to-top.js
+++ b/static/scroll-to-top.js
@@ -7,13 +7,18 @@ window.addEventListener('load', function () {
         return;
     }
 
-    let lastScrollY = window.scrollY;
-    const topMargin = 80; // Always show the navbar within px of the top
+    const scrollThreshold = 80;
 
+    if (window.scrollY >= scrollThreshold) {
+        $scrollToTop.classList.remove('hidden');
+        $scrollToTop.classList.add('show');
+    }
+
+    let lastScrollY = window.scrollY;
     // TODO: Extract `debounce` implementation to shared module or something
     window.addEventListener('scroll', debounce(() => {
         const currentScrollY = window.scrollY;
-        if (currentScrollY >= topMargin) {
+        if (currentScrollY >= scrollThreshold) {
             $scrollToTop.classList.remove('hidden');
             $scrollToTop.classList.add('show');
         } else {

--- a/templates/base.html
+++ b/templates/base.html
@@ -169,6 +169,11 @@
     {% endblock header %}
 
     <main>
+        <div id="scroll-to-top" class="hidden">
+            <svg class="w-6 h-6 text-gray-800 dark:text-white" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="none" viewBox="0 0 24 24">
+                <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m5 15 7-7 7 7"/>
+            </svg>
+        </div>
       {% block search %}
       <div class="search-container only-phone-visible">
         <input type="search" class="search" autocomplete="off" placeholder="Search...">
@@ -193,6 +198,7 @@
     <script type="text/javascript" src="{{ get_url(path='elasticlunr.min.js') }}" defer></script>
     <script type="text/javascript" src="{{ get_url(path='search.js') }}" defer></script>
     <script type="text/javascript" src="{{ get_url(path='snow.js') | safe }}" defer></script>
+    <script type="text/javascript" src="{{ get_url(path='scroll-to-top.js') | safe }}" defer></script>
   </body>
   {% block js %}
   {% endblock js %}


### PR DESCRIPTION
Closes: #22

- Simple implementation, reuse the sticky navbar threshold and the `debounce` implementation of the search bar.
- Adapts to light/dark theme


## 🖥️ Desktop view

<img width="600" alt="Blog entry text with a button surrounded with a red box at the bottom right" src="https://github.com/user-attachments/assets/2e08e408-0a30-4b95-b47c-0340b843ac58" />

<img width="600" alt="Blog entry text with a button surrounded with a red box at the bottom right" src="https://github.com/user-attachments/assets/e8a694b1-19eb-4b87-bd8f-ad321f0c290d" />


## 📱 Mobile view

<img width="390" alt="Blog entry text with a button surrounded with a red box at the bottom right" src="https://github.com/user-attachments/assets/b772c4a0-820a-427f-ba37-7771795838bd" />
<img width="390" alt="Blog entry text with a button surrounded with a red box at the bottom right" src="https://github.com/user-attachments/assets/39e5fa7e-5e32-499d-a94d-346855346d1a" />


