### PR TITLE
Add margin right and smaller font-size to tags in "readings" page

### DIFF
--- a/sass/custom.scss
+++ b/sass/custom.scss
@@ -144,11 +144,12 @@ a img {
     display: none;
 
     &.reading-tags__long {
-      font-size: 1em;
       display: inline;
       float: right;
       font-style: italic;
       list-style: none;
+      margin-right: 0.6em;
+      font-size: medium;
     }
 
     .reading-tag {


### PR DESCRIPTION
## 📚 Description

Change CSS from `tags` section in `Readings` page:

---


👈🏼  OLD <> NEW 👉🏼 
<img width="1905" alt="image" src="https://github.com/user-attachments/assets/daeb914f-b458-4426-9ffe-aa12d26f002a" />
