### PR TITLE
Fix mismatched hover border on cards, TOC, and nav links

### DIFF
--- a/sass/base/_typography.scss
+++ b/sass/base/_typography.scss
@@ -145,12 +145,13 @@ a {
   text-decoration: none;
   transition: color 0.2s ease;
 
-  // Plain text links get the recolor + underline on hover. Button-styled
-  // anchors (btn/button/cta/view-all/pill tags) opt out: they keep their own
-  // bg/color and must never inherit the underline border, which looks broken
-  // on a solid-blue button. Without the blog-post__tag opt-out this recolor
-  // beats its own :hover and paints blue text on the blue hover bg.
-  &:hover:not([class*="btn"]):not([class*="button"]):not([class*="cta"]):not(.view-all):not(.header-left):not(.blog-post__tag):not(.talk-single__tag):not(.talk-single__project-link) {
+  // Plain prose links get the recolor + underline on hover. :where() pins this
+  // at a:hover specificity (0,1,1) so any component's own :hover wins: a card or
+  // TOC/nav/footer link that sets its own border-color or `border-bottom: none`
+  // keeps a uniform border instead of this underline painting a mismatched line
+  // across its bottom edge. Prose links have no such :hover, so they still get
+  // the treatment. The button/tag list stays as a belt-and-suspenders opt-out.
+  &:hover:where(:not([class*="btn"]):not([class*="button"]):not([class*="cta"]):not(.view-all):not(.header-left):not(.blog-post__tag):not(.talk-single__tag):not(.talk-single__project-link)) {
     color: var(--accent-overlay-color);
     border-bottom: 1px solid var(--accent-color-light);
   }


### PR DESCRIPTION
## Problem

On hover, bordered links (Related readings cards, TOC items, nav and footer links) showed a mismatched `border-bottom`: near-white in dark mode, a lighter blue in light mode, painted across their own accent border. Reported on the Related readings pills and the TOC.

## Cause

The global `a:hover` prose-underline rule in `base/_typography.scss` wrapped its opt-out list in a long `:not()` chain. Each `:not(.x)` adds specificity, pushing the rule to roughly `(0,9,1)`, which beat every component's own `:hover` (around `(0,2,0)`). So components could not opt out: the ~24 `border-bottom: none` hover overrides scattered across the codebase were silently ignored.

## Fix

Wrap the denylist in `:where()`, which contributes zero specificity, pinning the rule at plain `a:hover` `(0,1,1)`. Now any component `:hover` wins:

- Cards, TOC, nav and footer links keep a uniform border (or honor their own `border-bottom: none`).
- Plain prose links, which have no `:hover` of their own, still get the recolor and underline.

One change fixes the whole class of issue and removes the need to keep growing the denylist.
