### PR TITLE
Give narrow screens a collapsible table of contents

### DIFF
--- a/sass/components/_toc.scss
+++ b/sass/components/_toc.scss
@@ -68,8 +68,31 @@
       scrollbar-color: var(--preview-divider-color) transparent;
     }
 
+    // Narrow screens: the sidebar becomes a collapsed disclosure above the article
+    // rather than disappearing. Static position, full width, no sticky and no
+    // viewport-height cap, so it never covers the text it links to.
     @media (max-width: 1024px) {
-      display: none;
+      width: 100%;
+      max-height: none;
+      position: static;
+      overflow: visible;
+      margin-bottom: 1.5rem;
+      padding: 0.5rem 0.75rem;
+
+      .toc-header {
+        display: none;
+      }
+
+      .toc-list {
+        display: none;
+        margin-top: 0.5rem;
+        max-height: 50vh;
+        overflow-y: auto;
+      }
+
+      &[data-toc-open="true"] .toc-list {
+        display: block;
+      }
     }
 
     // Scrolling down: navbar hidden, more vertical space available
@@ -255,3 +278,46 @@
   }
 }
 
+
+// Disclosure that opens the list on narrow screens. Desktop keeps the always-open
+// sidebar, so this is hidden there.
+.toc-mobile-toggle {
+  display: none;
+  width: 100%;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  padding: 0.35rem 0;
+  background: none;
+  border: none;
+  color: var(--heading-color);
+  font-size: 0.9rem;
+  font-weight: 600;
+  cursor: pointer;
+
+  &__chevron {
+    width: 16px;
+    height: 16px;
+    flex-shrink: 0;
+    color: var(--color-subtitle);
+    transition: transform 0.2s ease;
+  }
+
+  &:hover {
+    border-bottom: none;
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--accent-color);
+    outline-offset: 2px;
+    border-radius: 6px;
+  }
+
+  @media (max-width: 1024px) {
+    display: flex;
+  }
+}
+
+[data-toc-open="true"] .toc-mobile-toggle__chevron {
+  transform: rotate(180deg);
+}

--- a/static/toc.js
+++ b/static/toc.js
@@ -67,6 +67,27 @@
 
   // One listener on the list instead of one per link: the markup arrives from the
   // server, so there is nothing to bind at creation time.
+  function bindMobileToggle() {
+    const btn = tocContainerRef.querySelector('.toc-mobile-toggle');
+    if (!btn) return;
+
+    btn.addEventListener('click', function () {
+      const open = tocContainerRef.dataset.tocOpen === 'true';
+      tocContainerRef.dataset.tocOpen = open ? 'false' : 'true';
+      btn.setAttribute('aria-expanded', open ? 'false' : 'true');
+    });
+
+    // Following a link is the point of opening it, so close it again.
+    const list = tocContainerRef.querySelector('.toc-list');
+    if (list) {
+      list.addEventListener('click', function (e) {
+        if (!e.target.closest('.toc-link')) return;
+        tocContainerRef.dataset.tocOpen = 'false';
+        btn.setAttribute('aria-expanded', 'false');
+      });
+    }
+  }
+
   function bindTOCLinks() {
     const list = tocContainerRef.querySelector('.toc-list');
     if (!list) return;
@@ -240,9 +261,13 @@
       return;
     }
 
+    // Narrow screens show the panel as a collapsed disclosure above the article,
+    // so the desktop show/hide switch does not apply, but the links still do.
     if (compactMediaQuery.matches) {
-      setTOCState(true, false);
+      setTOCState(false, false);
       hideToggle();
+      bindTOCLinks();
+      bindMobileToggle();
       return;
     }
 

--- a/templates/partials/toc.html
+++ b/templates/partials/toc.html
@@ -44,6 +44,30 @@
   aria-label="{{ trans(key='toc_header_title', lang=lang) }}">
   <div id="reading-progress" class="reading-progress"></div>
 
+  {# Narrow screens hide the desktop panel and get this disclosure instead: a post
+     of any length was unnavigable on a phone, which is where most readers are. The
+     list ships collapsed at that width so opening it is the only thing that moves,
+     and toc.js binds the button. Without JS the noscript rule below expands it,
+     because a control that cannot open is worse than no control. #}
+  <button type="button"
+          class="toc-mobile-toggle"
+          aria-expanded="false"
+          aria-controls="toc-list">
+    <span class="toc-mobile-toggle__label">{{ trans(key="toc_header_title", lang=lang) }}</span>
+    <svg class="toc-mobile-toggle__chevron" viewBox="0 0 16 16" aria-hidden="true" focusable="false">
+      <path d="M4 6l4 4 4-4" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" />
+    </svg>
+  </button>
+  <noscript>
+    <style>@media (max-width: 1024px) {
+      /* Matches the compiled selector, which nests under .blog-post-layout: a
+         shorter one loses on specificity and the list stays shut with no way to
+         open it. */
+      .blog-post-layout #toc-container .toc-list { display: block; }
+      .toc-mobile-toggle { display: none; }
+    }</style>
+  </noscript>
+
   <div class="toc-header">
     <a class="toc-title" href="#">{{ trans(key="toc_header_title", lang=lang) }}</a>
     <button type="button" class="toc-close" aria-label="{{ trans(key='toc_close_label', lang=lang) }}">
@@ -53,7 +77,7 @@
     </button>
   </div>
 
-  <ul class="toc-list" role="list">
+  <ul class="toc-list" id="toc-list" role="list">
     {% for a in page.toc %}
       <li class="toc-item toc-h{{ a.level }}">
         <a class="toc-link" href="#{{ a.id }}">{{ a.title }}</a>


### PR DESCRIPTION
The TOC panel was `display: none` below 1024px, so a fourteen minute post was unnavigable on a phone. The list has been server-rendered since #40, so this is presentation only.

## What it does

Below 1024px the sidebar becomes a disclosure above the article: static position, full width, no sticky and no viewport-height cap, so it never covers the text it links to. The list ships **collapsed** at that width, so opening it is the only thing that moves. Following a link closes it again, since navigating is the point of opening it.

Measured at a **real 420px viewport** (an iframe, because headless Chrome floors its window at 500px and renders wider than it screenshots):

| width | panel | toggle | list | aria-expanded | scrollWidth |
| --- | --- | --- | --- | --- | --- |
| 420 collapsed | 46px | shown | hidden | `false` | 420 |
| 420 expanded | 504px | shown | shown | `true` | 420 |
| 1280 | 780px | hidden | shown | n/a | 1280 |

CLS stays **0.0000** at 500px and 1280px. Desktop behaviour is unchanged.

## Two things worth reading

**The no-JS fallback failed silently on the first attempt.** A button that cannot open anything is worse than no button, so a `noscript` rule expands the list and hides the control. My first version used `#toc-container .toc-list`, which loses on specificity to the compiled `.blog-post-layout #toc-container .toc-list`, leaving the list shut with no way to open it. Fixed by matching the compiled selector, and verified by promoting the rule to a live `<style>` and measuring computed display: `list=block`, `toggle=none`, 22 links at 420px.

**A verification method I used earlier does not work.** Chrome's `--disable-javascript` is ignored by the current build: with that flag the inline theme script still ran and still set `color-theme` on `<html>`. `--blink-settings=scriptEnabled=false` does disable scripting, but then `--screenshot` writes no file at all. So the "works with JS disabled" line in #40 was tested with a flag that did nothing. The conclusion there happened to be right, because that TOC is server-rendered, but the test did not establish it.

## Known nit

On mobile the disclosure sits above the "All posts" back row, because `#toc-container` precedes `.blog-post-main` in the DOM and the back link is nested inside it. Reordering would mean restructuring the layout, so it stays for now. Nav before content is defensible, but say the word if you want it under the back row.