### PR TITLE
Give each post series its own page

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -137,6 +137,11 @@ footer_col_creative = "Creative"
 footer_col_about = "About"
 footer_tagline = "Building software, teams, and ideas."
 all_tags = "All tags"
+series_title = "Series"
+series_intro = "Posts written to be read in order. Each series builds one idea across several parts."
+series_parts = "parts"
+series_start = "Start reading"
+series_all = "All series"
 post = "post"
 posts = "posts"
 nav_topics = "Topics"
@@ -414,6 +419,11 @@ footer_col_creative = "Creativo"
 footer_col_about = "Sobre mí"
 footer_tagline = "Construyendo software, equipos e ideas."
 all_tags = "Todas las etiquetas"
+series_title = "Series"
+series_intro = "Artículos escritos para leerse en orden. Cada serie construye una idea a lo largo de varias partes."
+series_parts = "partes"
+series_start = "Empezar a leer"
+series_all = "Todas las series"
 post = "artículo"
 posts = "artículos"
 nav_topics = "Temas"
@@ -519,22 +529,32 @@ svc_consulting_paused_banner = "La consultoría está en pausa. Ahora mismo no a
 [extra.series.bitcoin]
 title = "Bitcoin Series"
 title_es = "Serie Bitcoin"
+desc = "How Bitcoin actually works, from the blockchain up to the Lightning Network, in plain terms."
+desc_es = "Cómo funciona Bitcoin de verdad, desde la blockchain hasta la Lightning Network, en términos claros."
 
 [extra.series.ai]
 title = "AI Series"
 title_es = "Serie IA"
+desc = "Working with AI agents as a team of specialists: context, tooling, and where the human still decides."
+desc_es = "Trabajar con agentes de IA como un equipo de especialistas: contexto, herramientas y dónde decide el humano."
 
 [extra.series.craftsmanship]
 title = "Software Craftsmanship Series"
 title_es = "Serie Artesanía del Software"
+desc = "The practices that keep code changeable: TDD, refactoring, clean design, and the habits around them."
+desc_es = "Las prácticas que mantienen el código cambiable: TDD, refactoring, diseño limpio y los hábitos alrededor."
 
 [extra.series.leadership]
 title = "Leadership & Teams Series"
 title_es = "Serie Liderazgo y Equipos"
+desc = "Leading engineers without leaving the code: priorities, trust, and the hard conversations."
+desc_es = "Liderar ingenieros sin dejar el código: prioridades, confianza y las conversaciones difíciles."
 
 [extra.series.agile]
 title = "Agile & XP Series"
 title_es = "Serie Agile y XP"
+desc = "Agile and XP as practised rather than certified: short feedback loops, pairing, and continuous everything."
+desc_es = "Agile y XP en la práctica, no en el certificado: ciclos de feedback cortos, pair programming y todo en continuo."
 
 [[extra.topics]]
 title = "Leadership & People"

--- a/content/series/_index.es.md
+++ b/content/series/_index.es.md
@@ -1,0 +1,7 @@
++++
+title = "Series | Chemaclass"
+description = "Series de artículos escritos para leerse en orden: Bitcoin, agentes de IA, artesanía del software, liderazgo y práctica agile."
+template = "series/list.html"
+page_template = "series/single.html"
+sort_by = "weight"
++++

--- a/content/series/_index.md
+++ b/content/series/_index.md
@@ -1,0 +1,7 @@
++++
+title = "Series | Chemaclass"
+description = "Post series written to be read in order: Bitcoin, AI agents, software craftsmanship, leadership, and agile practice."
+template = "series/list.html"
+page_template = "series/single.html"
+sort_by = "weight"
++++

--- a/content/series/agile.es.md
+++ b/content/series/agile.es.md
@@ -1,0 +1,8 @@
++++
+title = "Serie Agile y XP"
+weight = 5
+template = "series/single.html"
+
+[extra]
+series = "agile"
++++

--- a/content/series/agile.md
+++ b/content/series/agile.md
@@ -1,0 +1,8 @@
++++
+title = "Agile & XP Series"
+weight = 5
+template = "series/single.html"
+
+[extra]
+series = "agile"
++++

--- a/content/series/ai.es.md
+++ b/content/series/ai.es.md
@@ -1,0 +1,8 @@
++++
+title = "Serie IA"
+weight = 2
+template = "series/single.html"
+
+[extra]
+series = "ai"
++++

--- a/content/series/ai.md
+++ b/content/series/ai.md
@@ -1,0 +1,8 @@
++++
+title = "AI Series"
+weight = 2
+template = "series/single.html"
+
+[extra]
+series = "ai"
++++

--- a/content/series/bitcoin.es.md
+++ b/content/series/bitcoin.es.md
@@ -1,0 +1,8 @@
++++
+title = "Serie Bitcoin"
+weight = 1
+template = "series/single.html"
+
+[extra]
+series = "bitcoin"
++++

--- a/content/series/bitcoin.md
+++ b/content/series/bitcoin.md
@@ -1,0 +1,8 @@
++++
+title = "Bitcoin Series"
+weight = 1
+template = "series/single.html"
+
+[extra]
+series = "bitcoin"
++++

--- a/content/series/craftsmanship.es.md
+++ b/content/series/craftsmanship.es.md
@@ -1,0 +1,8 @@
++++
+title = "Serie Artesanía del Software"
+weight = 3
+template = "series/single.html"
+
+[extra]
+series = "craftsmanship"
++++

--- a/content/series/craftsmanship.md
+++ b/content/series/craftsmanship.md
@@ -1,0 +1,8 @@
++++
+title = "Software Craftsmanship Series"
+weight = 3
+template = "series/single.html"
+
+[extra]
+series = "craftsmanship"
++++

--- a/content/series/leadership.es.md
+++ b/content/series/leadership.es.md
@@ -1,0 +1,8 @@
++++
+title = "Serie Liderazgo y Equipos"
+weight = 4
+template = "series/single.html"
+
+[extra]
+series = "leadership"
++++

--- a/content/series/leadership.md
+++ b/content/series/leadership.md
@@ -1,0 +1,8 @@
++++
+title = "Leadership & Teams Series"
+weight = 4
+template = "series/single.html"
+
+[extra]
+series = "leadership"
++++

--- a/sass/page.scss
+++ b/sass/page.scss
@@ -32,6 +32,7 @@
 // 6. Pages
 @import "pages/404";
 @import "pages/talks";
+@import "pages/series";
 @import "pages/books";
 @import "pages/music";
 @import "pages/cv";

--- a/sass/pages/_series.scss
+++ b/sass/pages/_series.scss
@@ -1,0 +1,245 @@
+// Series index and per-series pages. Reuses the card language of the tag pages:
+// bordered surface, accent border on hover, muted meta.
+
+.series-page {
+  &__header {
+    text-align: center;
+    margin-bottom: 2.5rem;
+
+    h1 {
+      margin-bottom: 0.5rem;
+    }
+  }
+
+  &__intro {
+    color: var(--color-subtitle);
+    font-size: 1.1rem;
+    line-height: 1.6;
+    margin: 0 auto;
+    max-width: 700px;
+  }
+
+  &__list {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+  }
+}
+
+.series-card {
+  padding: 1.25rem 1.5rem;
+  border: 1px solid var(--preview-divider-color);
+  border-radius: 12px;
+  background: var(--search-input-bg);
+  transition: border-color 0.2s ease;
+
+  &:hover {
+    border-color: var(--accent-color);
+  }
+
+  &__head {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 1rem;
+  }
+
+  &__title {
+    font-size: 1.15rem;
+    font-weight: 600;
+    margin: 0;
+
+    a {
+      color: var(--heading-color);
+      text-decoration: none;
+
+      &:hover {
+        color: var(--accent-color);
+        border-bottom: none;
+      }
+    }
+  }
+
+  &__count {
+    flex-shrink: 0;
+    font-size: 0.75rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: var(--color-subtitle);
+  }
+
+  &__desc {
+    color: var(--color-subtitle);
+    font-size: 0.95rem;
+    line-height: 1.6;
+    margin: 0.5rem 0 0.75rem;
+  }
+
+  &__parts {
+    margin: 0 0 0.75rem;
+    padding-left: 1.25rem;
+    color: var(--color-subtitle);
+    font-size: 0.9rem;
+
+    li {
+      margin-bottom: 0.2rem;
+    }
+
+    a {
+      color: var(--body-color);
+      text-decoration: none;
+
+      &:hover {
+        color: var(--accent-color);
+      }
+    }
+  }
+
+  &__more {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    font-size: 0.85rem;
+    font-weight: 500;
+    color: var(--accent-color);
+    text-decoration: none;
+
+    &:hover {
+      border-bottom: none;
+      text-decoration: underline;
+    }
+  }
+}
+
+.series-single {
+  &__back {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    color: var(--color-subtitle);
+    text-decoration: none;
+    font-size: 0.9rem;
+    margin-bottom: 1.5rem;
+
+    &:hover {
+      color: var(--accent-color);
+      border-bottom: none;
+    }
+  }
+
+  &__header {
+    margin-bottom: 2rem;
+    padding-bottom: 1.5rem;
+    border-bottom: 1px solid var(--preview-divider-color);
+  }
+
+  &__desc {
+    color: var(--color-subtitle);
+    font-size: 1.05rem;
+    line-height: 1.6;
+    margin: 0.5rem 0 0.75rem;
+    max-width: 700px;
+  }
+
+  &__count {
+    font-size: 0.8rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: var(--color-subtitle);
+    margin: 0;
+  }
+
+  &__parts {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+  }
+}
+
+.series-part {
+  display: flex;
+  gap: 1rem;
+  padding: 1rem 1.25rem;
+  border: 1px solid var(--preview-divider-color);
+  border-radius: 12px;
+  background: var(--search-input-bg);
+  transition: border-color 0.2s ease;
+
+  &:hover {
+    border-color: var(--accent-color);
+  }
+
+  &__number {
+    flex-shrink: 0;
+    width: 1.75rem;
+    height: 1.75rem;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 50%;
+    background: var(--preview-divider-color);
+    color: var(--color-subtitle);
+    font-size: 0.8rem;
+    font-weight: 700;
+  }
+
+  &__body {
+    min-width: 0;
+  }
+
+  &__title {
+    font-size: 1.05rem;
+    font-weight: 600;
+    margin: 0;
+    line-height: 1.4;
+
+    a {
+      color: var(--heading-color);
+      text-decoration: none;
+
+      &:hover {
+        color: var(--accent-color);
+        border-bottom: none;
+      }
+    }
+  }
+
+  &__subtitle {
+    color: var(--accent-color);
+    font-size: 0.9rem;
+    margin: 0.2rem 0 0;
+  }
+
+  &__desc {
+    color: var(--color-subtitle);
+    font-size: 0.9rem;
+    line-height: 1.55;
+    margin: 0.4rem 0 0;
+  }
+
+  &__meta {
+    font-size: 0.78rem;
+    color: var(--color-subtitle);
+    margin: 0.4rem 0 0;
+  }
+}
+
+@media (max-width: $breakpoint-phone) {
+  .series-card {
+    padding: 1rem;
+  }
+
+  .series-card__head {
+    flex-direction: column;
+    gap: 0.25rem;
+  }
+
+  .series-part {
+    padding: 0.85rem;
+  }
+}

--- a/templates/base.html
+++ b/templates/base.html
@@ -551,6 +551,7 @@
             <ul class="page-footer__list">
               <li><a href="{{ lp }}/blog/">{{ trans(key="nav_blog", lang=lang) }}</a></li>
               <li><a href="{{ lp }}/readings/">{{ trans(key="nav_readings", lang=lang) }}</a></li>
+              <li><a href="{{ lp }}/series/">{{ trans(key="series_title", lang=lang) }}</a></li>
               <li><a href="{{ lp }}/topics/">{{ trans(key="nav_topics", lang=lang) }}</a></li>
             </ul>
           </div>

--- a/templates/series/list.html
+++ b/templates/series/list.html
@@ -1,0 +1,78 @@
+{% extends "base.html" %}
+
+{% import "partials/macros.html" as macros %}
+
+{% block title %}
+  {{ trans(key="series_title", lang=lang) }} | Chemaclass
+{% endblock %}
+
+{% block styles %}
+{{ macros::page_styles(css='page.css') }}
+{% endblock styles %}
+
+{% block posthead %}
+  {% for entry in section.pages %}
+    <link rel="prerender" href="{{ entry.permalink }}" />
+  {% endfor %}
+{% endblock posthead %}
+
+{% block content %}
+<div class="series-page">
+  <header class="series-page__header">
+    <h1>{{ trans(key="series_title", lang=lang) }}</h1>
+    <p class="series-page__intro">{{ trans(key="series_intro", lang=lang) }}</p>
+  </header>
+
+  <div class="series-page__list">
+    {# Each page under content/series/ binds a URL to a key in
+       config.extra.series, which owns the title and the description. The posts
+       themselves are found by their own extra.series, so adding a post to a series
+       needs no change here. #}
+    {% set blog = get_section(path="blog/_index.md", lang=lang) %}
+    {% for entry in section.pages %}
+      {% set key = entry.extra.series %}
+      {% set conf = config.extra.series[key] %}
+
+      {% set_global parts = [] %}
+      {% for post in blog.pages %}
+        {% if post.extra.series and post.extra.series == key %}
+          {% set_global parts = parts | concat(with=post) %}
+        {% endif %}
+      {% endfor %}
+      {% set parts = parts | sort(attribute="extra.series_order") %}
+
+      {% if parts | length > 0 %}
+      <article class="series-card">
+        <div class="series-card__head">
+          <h2 class="series-card__title">
+            <a href="{{ entry.permalink }}">
+              {% if lang == "es" and conf.title_es %}{{ conf.title_es }}{% else %}{{ conf.title }}{% endif %}
+            </a>
+          </h2>
+          <span class="series-card__count">{{ parts | length }} {{ trans(key="series_parts", lang=lang) }}</span>
+        </div>
+
+        {% if conf.desc %}
+          <p class="series-card__desc">
+            {% if lang == "es" and conf.desc_es %}{{ conf.desc_es }}{% else %}{{ conf.desc }}{% endif %}
+          </p>
+        {% endif %}
+
+        <ol class="series-card__parts">
+          {% for post in parts | slice(end=3) %}
+            <li><a href="{{ post.permalink }}">{{ post.title }}</a></li>
+          {% endfor %}
+        </ol>
+
+        <a class="series-card__more" href="{{ entry.permalink }}">
+          {{ trans(key="series_start", lang=lang) }}
+          <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <path d="M5 12h14M12 5l7 7-7 7"/>
+          </svg>
+        </a>
+      </article>
+      {% endif %}
+    {% endfor %}
+  </div>
+</div>
+{% endblock content %}

--- a/templates/series/single.html
+++ b/templates/series/single.html
@@ -1,0 +1,81 @@
+{% extends "base.html" %}
+
+{% import "partials/macros.html" as macros %}
+
+{% block title %}
+{%- set conf = config.extra.series[page.extra.series] -%}
+{%- set series_name = conf.title -%}
+{%- if lang == "es" and conf.title_es -%}{%- set series_name = conf.title_es -%}{%- endif -%}
+{%- set series_desc = conf.desc | default(value="") -%}
+{%- if lang == "es" and conf.desc_es -%}{%- set series_desc = conf.desc_es -%}{%- endif -%}
+{{ series_name }} | Chemaclass{% endblock %}
+
+{% block description %}
+{%- set conf = config.extra.series[page.extra.series] -%}
+{%- set series_name = conf.title -%}
+{%- if lang == "es" and conf.title_es -%}{%- set series_name = conf.title_es -%}{%- endif -%}
+{%- set series_desc = conf.desc | default(value="") -%}
+{%- if lang == "es" and conf.desc_es -%}{%- set series_desc = conf.desc_es -%}{%- endif -%}
+
+  {% if series_desc %}
+    <meta name="description" content="{{ series_desc }}" />
+    <meta name="twitter:description" content="{{ series_desc }}">
+  {% endif %}
+{% endblock description %}
+
+{% block styles %}
+{{ macros::page_styles(css='page.css') }}
+{% endblock styles %}
+
+{% block content %}
+{%- set conf = config.extra.series[page.extra.series] -%}
+{%- set series_name = conf.title -%}
+{%- if lang == "es" and conf.title_es -%}{%- set series_name = conf.title_es -%}{%- endif -%}
+{%- set series_desc = conf.desc | default(value="") -%}
+{%- if lang == "es" and conf.desc_es -%}{%- set series_desc = conf.desc_es -%}{%- endif -%}
+{% set key = page.extra.series %}
+{% set blog = get_section(path="blog/_index.md", lang=lang) %}
+{% set_global parts = [] %}
+{% for post in blog.pages %}
+  {% if post.extra.series and post.extra.series == key %}
+    {% set_global parts = parts | concat(with=post) %}
+  {% endif %}
+{% endfor %}
+{% set parts = parts | sort(attribute="extra.series_order") %}
+
+<div class="series-single">
+  <a href="{{ macros::lang_path(path='/series/', lang=lang) }}" class="series-single__back">
+    {{ macros::back_arrow() }}
+    {{ trans(key="series_all", lang=lang) }}
+  </a>
+
+  <header class="series-single__header">
+    <h1>{{ series_name }}</h1>
+    {% if series_desc %}<p class="series-single__desc">{{ series_desc }}</p>{% endif %}
+    <p class="series-single__count">{{ parts | length }} {{ trans(key="series_parts", lang=lang) }}</p>
+  </header>
+
+  {# Ordered by extra.series_order, which is the reading order the author set, not
+     the publication date. A gap or a repeat here shows up as a wrong number. #}
+  <ol class="series-single__parts">
+    {% for post in parts %}
+      <li class="series-part">
+        <span class="series-part__number">{{ post.extra.series_order }}</span>
+        <div class="series-part__body">
+          <h2 class="series-part__title"><a href="{{ post.permalink }}">{{ post.title }}</a></h2>
+          {% if post.extra.subtitle %}
+            <p class="series-part__subtitle">{{ post.extra.subtitle }}</p>
+          {% endif %}
+          {% if post.description %}
+            <p class="series-part__desc">{{ post.description }}</p>
+          {% endif %}
+          <p class="series-part__meta">
+            <time datetime="{{ post.date }}">{{ macros::format_date(date=post.date, lang=lang) }}</time>
+            {% if post.reading_time %} &middot; {{ post.reading_time }} min{% endif %}
+          </p>
+        </div>
+      </li>
+    {% endfor %}
+  </ol>
+</div>
+{% endblock content %}


### PR DESCRIPTION
Five series existed in `config.toml` and only ever surfaced *inside* a post, as prev/next navigation. There was no way to see what a series covers, no way to start one from the beginning, and nothing for a search engine to index.

## What is new

**`/series/`** lists all five with a description, a part count and the first three titles.

**`/series/<key>/`** lists every part in reading order, numbered by `extra.series_order` rather than by date, with subtitle, description and reading time.

Both in English and Spanish, so 10 new pages plus 2 section indexes. Footer gains a link under Explore.

## How it is wired

The content files under `content/series/` are deliberately thin: they bind a URL to a key, nothing more. `config.toml` owns the title and the description in both languages, and posts are gathered by their own `extra.series`, so **adding a post to a series still needs nothing beyond its front matter**. Five series descriptions are new, EN + ES.

## Verified in a clean worktree

```
series pages built: 10
/series/          5 cards, counts: 6 parts, 8 parts, 7 parts, 8 parts, 6 parts
/es/series/       5 cards, counts: 6 partes, 8 partes, 7 partes, 8 partes, 6 partes
/series/bitcoin/  parts [1, 2, 3, 4, 5, 6], meta description present
./build.sh        exit 0
```

The AI series shows **8** parts although 10 posts carry `series = "ai"`. That is correct: orders 9 and 10 are still `draft = true`, so Zola excludes them. I checked rather than assumed.

## Note for the next person in these templates

Tera does not carry a top-level `{% set %}` into a `{% block %}` when a template extends another, so each block in `series/single.html` looks up the series config itself. My first version set it once at the top and failed the build with `Variable series_name not found in context`.

## Unrelated, and satisfying

The zero-enrichment guard fixed in #47 fired for real during this work: `./build.sh` in the main checkout stopped with *"built with base_url http://127.0.0.1:1111, but this script builds https://chemaclass.com URLs. A running `zola serve` overwrites public/"*. That is exactly the failure it was written for, reported correctly, in the wild.