### PR TITLE
Fix the profile page stuck on its skeleton

### DIFF
--- a/static/profile.js
+++ b/static/profile.js
@@ -24,8 +24,10 @@
   // { posts: [], series: {}, lang: 'en' } fallback this replaces turned that bug
   // into a dashboard that told the reader they had finished nothing and read it
   // back to them in English. Let the SyntaxError reach the console instead.
-  var payload = JSON.parse(dataEl.textContent);
+  var parsed = JSON.parse(dataEl.textContent);
 
+  // Shape check on top of the parse: a payload that parsed but lacks `series`
+  // still threw further down, which looked identical to this page never loading.
   var payload = {
     posts: Array.isArray(parsed.posts) ? parsed.posts : [],
     series: (parsed.series && typeof parsed.series === 'object') ? parsed.series : {},


### PR DESCRIPTION
`/profile/` rendered its loading placeholders and never replaced them, for every visitor. My bug, introduced in #44.

## Cause

Merging the error-handling and typing passes, I kept one branch's parse line and the other branch's normalisation block:

```js
var payload = JSON.parse(dataEl.textContent);

var payload = {
  posts: Array.isArray(parsed.posts) ? parsed.posts : [],   // parsed is not defined
  ...
};
```

`parsed` was never bound, so the script threw a `ReferenceError` before `render()` ran and the page kept its skeleton. The parse is named `parsed` again and `payload` is the normalised shape, which is what both passes intended: parse loudly (the payload is generated at build time, so a failure is a template bug), then check the shape (a payload without `series` threw further down anyway).

## Why every check passed

- `new Function(src)` proves a file **parses**. A `ReferenceError` is a runtime failure, so all 12 JS files passed that check in #44.
- The build output was unaffected: this page is rendered in the browser, so `zola build`, the artefact diffs and the HTML comparison were all identical and all irrelevant.
- The live payload was and is valid: I fetched it from production and it parses, with 164 posts. The data was never the problem.

## Verified by executing it, not by parsing it

Loaded the page in headless Chrome and inspected the result rather than the source:

```
errors=[]  appChildren=6  skeletons=0  text="Overall progressPosts you've finished ac..."
```

Screenshot shows all sections rendering: overall progress (0 of 75 blog posts, 0 of 89 readings), per-series bars for all five series, and the rest.

## No automated guard, deliberately

I wrote a static checker for identifiers that are read but never bound, and threw it away: it flagged 10 of 12 files, almost entirely false positives, because scope analysis is not something a regex can do. A checker that cries wolf gets ignored and is worse than none.

The check that would actually work is a smoke test: build, serve, load a handful of pages in headless Chrome, fail on any uncaught exception. That needs a browser in CI and is worth doing on its own, not smuggled into a one-line fix. For now the honest statement is that JS runtime errors on browser-rendered pages are not covered by CI, and this one reached production because of it.