### PR TITLE
Fix the Spanish site, topic coverage, and five silent defects

### DIFF
--- a/.claude/skills/new-reading/SKILL.md
+++ b/.claude/skills/new-reading/SKILL.md
@@ -13,8 +13,8 @@ argument-hint: "<book-title> by <author>"
 2. Read `.claude/skills/writing-style/SKILL.md` and `.claude/skills/writing-style/references/readings.md` (if present) and apply them as the tone and style guide
 3. Create the file at `content/readings/YYYY-MM-DD-slug.md` using today's date
 4. Replace template placeholders with actual content based on the book
-5. Fill the front matter: title, description, authors, tags, subtitle, pages, author, and `expand_preview = true` (the site default; nearly every reading uses it)
-6. Set `static_thumbnail` to the book's cover image URL (from Goodreads/Amazon if known)
+5. Fill the front matter: title, description, authors, tags, subtitle, pages, author
+6. Set `static_thumbnail` to the book's cover image URL (from Goodreads/Amazon if known), then run `python3 scripts/localize-reading-covers.py` to fetch it and rewrite the field to a local webp
 7. Add `<!-- more -->` marker after the introduction
 8. Fill `related_readings` in front matter with thematically similar readings, and optionally `related_posts` when a blog post covers the same theme (verify each target file exists)
 9. Set `draft = true`

--- a/.claude/skills/writing-style/references/readings.md
+++ b/.claude/skills/writing-style/references/readings.md
@@ -2,7 +2,7 @@
 
 A reading is a book-anchored takeaway note, not an argument. Shorter, more list-driven, points outward to the book. Template: `.claude/templates/reading.md`. The filename date is when the book was finished.
 
-- Front matter: `title`, `description`, `[taxonomies] tags`, `authors = [ ... ]`, `[extra] author`, `[extra] pages` (string), `[extra] subtitle` (the book's real subtitle or a short tagline; often left empty `""` when neither fits), `static_thumbnail` (external cover URL, Goodreads/Amazon), `expand_preview = true` (the default, used by nearly every reading), `related_readings`, optional `related_posts`.
+- Front matter: `title`, `description`, `[taxonomies] tags`, `authors = [ ... ]`, `[extra] author`, `[extra] pages` (string), `[extra] subtitle` (the book's real subtitle or a short tagline; often left empty `""` when neither fits), `static_thumbnail` (a local webp under `/images/readings/`; start from a Goodreads/Amazon URL and run `scripts/localize-reading-covers.py`), `related_readings`, optional `related_posts`.
 - **No `rating`, `verdict`, `score`, or buy-link fields exist. Do not invent them.**
 - No inline `![cover]` line in the body; the cover comes from `static_thumbnail`.
 - Length: ~400 to 800 words.

--- a/.claude/templates/reading.md
+++ b/.claude/templates/reading.md
@@ -9,8 +9,7 @@ tags = [ "tag1", "tag2" ]
 subtitle = "The Subtitle"
 pages = "0"
 author = "Author Name"
-static_thumbnail = "https://m.media-amazon.com/images/..."
-expand_preview = true
+static_thumbnail = "/images/readings/slug.webp"
 # pin = true           # optional; floats the reading to the top of /readings/.
 #                      # Only `true` does anything.
 related_readings = [
@@ -32,9 +31,12 @@ Field notes (see also .claude/skills/writing-style/references/readings.md):
   interpolates it into schema.org `numberOfPages`.
 - `author` (singular, under `[extra]`) is what every template renders. The
   top-level `authors` array is the Zola-native field and is not rendered.
-- `expand_preview` is currently INERT: no template, script, or JS reads it.
-  It is kept for consistency with the ~120 existing readings that set it.
-  Either wire it up or drop it from all of them, but do not assume it works.
+- `expand_preview` is gone. It was set in 122 readings and read by nothing, so
+  it was dropped from all of them. Do not reintroduce it.
+- `static_thumbnail` points at a local webp under `/images/readings/`. A remote
+  cover URL still works, but run `scripts/localize-reading-covers.py` to pull it
+  down: Zola cannot resize a remote image, and the page then depends on someone
+  else's CDN staying up.
 - `related_*` paths are relative to `content/`, keep the `.md` extension, and
   point at the ENGLISH file even inside a `.es.md` reading.
 -->

--- a/build.sh
+++ b/build.sh
@@ -72,6 +72,9 @@ zola build "$@"
 echo "Checking the Font Awesome subset covers every icon in use..."
 python3 scripts/check-icons.py
 
+echo "Checking /topics/ covers every tag..."
+python3 scripts/check-topics.py
+
 echo "Enriching search index with dates..."
 python3 scripts/enrich-search-index.py
 

--- a/config.toml
+++ b/config.toml
@@ -563,28 +563,28 @@ title = "Leadership & People"
 title_es = "Liderazgo y Personas"
 description = "Growing as a leader, building great teams, and the human side of software."
 description_es = "Crecer como líder, construir equipos y el lado humano del software."
-tags = ["leadership", "management", "team-management", "team-culture", "mentoring", "communication", "career", "professionalism", "self-improvement"]
+tags = ["leadership", "management", "team-management", "team-culture", "mentoring", "communication", "career", "self-improvement"]
 
 [[extra.topics]]
 title = "Mind & Knowledge"
 title_es = "Mente y Conocimiento"
 description = "Philosophy, psychology, productivity, and the pursuit of understanding."
 description_es = "Filosofía, psicología, productividad y la búsqueda del entendimiento."
-tags = ["philosophy", "psychology", "productivity", "fiction", "dystopia", "horror", "music"]
+tags = ["philosophy", "psychology", "productivity", "mindset", "fiction", "dystopia", "horror"]
 
 [[extra.topics]]
 title = "Software Craft & Testing"
 title_es = "Artesanía del Software y Testing"
 description = "Practices for writing better software: TDD, clean code, refactoring, and design."
 description_es = "Prácticas para escribir mejor software: TDD, código limpio, refactoring y diseño."
-tags = ["testing", "tdd", "clean-code", "refactoring", "code-review", "architecture", "software-design", "software-architecture", "ddd", "pair-programming", "xp", "agile"]
+tags = ["testing", "tdd", "clean-code", "refactoring", "code-review", "architecture", "software-design", "software-architecture", "ddd", "pair-programming", "xp", "agile", "scrum", "craftsmanship", "software", "engineering", "modular"]
 
 [[extra.topics]]
 title = "Bitcoin & Economics"
 title_es = "Bitcoin y Economía"
 description = "Sound money, Austrian economics, privacy, and the technology behind Bitcoin."
 description_es = "Dinero sólido, economía austriaca, privacidad y la tecnología detrás de Bitcoin."
-tags = ["bitcoin", "economics", "money", "finance", "investing", "cryptography", "privacy", "security", "encryption"]
+tags = ["bitcoin", "economics", "cryptography", "privacy", "security", "freedom"]
 
 [[extra.topics]]
 title = "Programming Languages & Tools"
@@ -592,6 +592,13 @@ title_es = "Lenguajes y Herramientas"
 description = "Hands-on content about specific languages, frameworks, and developer tooling."
 description_es = "Contenido práctico sobre lenguajes, frameworks y herramientas de desarrollo."
 tags = ["php", "golang", "lisp", "bash", "symfony", "docker", "git", "devops", "developer-tools", "bashunit", "gacela", "phel", "functional-programming"]
+
+[[extra.topics]]
+title = "AI & Agents"
+title_es = "IA y Agentes"
+description = "Working with AI agents, agentic coding, and what the tooling changes about the craft."
+description_es = "Trabajar con agentes de IA, agentic coding y lo que las herramientas cambian del oficio."
+tags = ["ai", "agentic-coding"]
 
 [[extra.topics]]
 title = "Speaking & Teaching"

--- a/content/blog/2022-02-26-update-your-team-to-be-more-extreme.es.md
+++ b/content/blog/2022-02-26-update-your-team-to-be-more-extreme.es.md
@@ -1,7 +1,7 @@
 +++
 title = "Actualiza tu Equipo para Ser Más Extreme"
 description = "Nuestra profesión está en constante evolución y exige aprendizaje continuo. Abrazar el cambio no es opcional en software. Hay que crear espacios para salir de nuestra zona de confort."
-updated_at = "2023-03-23"
+updated = "2023-03-23"
 [taxonomies]
 tags = [ "xp", "agile", "team-management", "mentoring", "tdd" ]
 [extra]

--- a/content/blog/2022-02-26-update-your-team-to-be-more-extreme.md
+++ b/content/blog/2022-02-26-update-your-team-to-be-more-extreme.md
@@ -1,7 +1,7 @@
 +++
 title = "Update Your Team to Be More Extreme"
 description = "Our profession is constantly evolving; therefore, it demands a non-stop learning process. Embracing the change is not optional in our software industry. We need to create spaces to get out of our comfort zone."
-updated_at = "2023-03-23"
+updated = "2023-03-23"
 [taxonomies]
 tags = [ "xp", "agile", "team-management", "mentoring", "tdd" ]
 [extra]

--- a/content/readings/2016-05-01-clean-code.es.md
+++ b/content/readings/2016-05-01-clean-code.es.md
@@ -9,7 +9,6 @@ subtitle = "Manual de artesanía ágil de software"
 pages = "460"
 author = "Robert C. Martin"
 static_thumbnail = "/images/readings/clean-code.webp"
-expand_preview = true
 related_posts = [
   "blog/2020-06-28-the-art-of-refactoring.md",
   "blog/2020-04-07-the-art-of-testing.md",

--- a/content/readings/2016-05-01-clean-code.md
+++ b/content/readings/2016-05-01-clean-code.md
@@ -9,7 +9,6 @@ subtitle = "A Handbook of Agile Software Craftsmanship"
 pages = "460"
 author = "Robert C. Martin"
 static_thumbnail = "/images/readings/clean-code.webp"
-expand_preview = true
 related_posts = [
   "blog/2020-06-28-the-art-of-refactoring.md",
   "blog/2020-04-07-the-art-of-testing.md",

--- a/content/readings/2016-07-15-97-things-every-programmer-should-know.es.md
+++ b/content/readings/2016-07-15-97-things-every-programmer-should-know.es.md
@@ -9,7 +9,6 @@ subtitle = "Sabiduría colectiva de los expertos"
 pages = "250"
 author = "Kevlin Henney"
 static_thumbnail = "/images/readings/97-things-every-programmer-should-know.webp"
-expand_preview = true
 related_readings = [
   "readings/2016-10-01-the-pragmatic-programmer.md",
   "readings/2016-05-01-clean-code.md",

--- a/content/readings/2016-07-15-97-things-every-programmer-should-know.md
+++ b/content/readings/2016-07-15-97-things-every-programmer-should-know.md
@@ -9,7 +9,6 @@ subtitle = "Collective whisdom from the experts"
 pages = "250"
 author = "Kevlin Henney"
 static_thumbnail = "/images/readings/97-things-every-programmer-should-know.webp"
-expand_preview = true
 related_readings = [
   "readings/2016-10-01-the-pragmatic-programmer.md",
   "readings/2016-05-01-clean-code.md",

--- a/content/readings/2016-08-01-the-clean-coder.es.md
+++ b/content/readings/2016-08-01-the-clean-coder.es.md
@@ -9,7 +9,6 @@ subtitle = "Un código de conducta para programadores profesionales"
 pages = "250"
 author = "Robert C. Martin"
 static_thumbnail = "/images/readings/the-clean-coder.webp"
-expand_preview = true
 related_readings = [
   "readings/2016-05-01-clean-code.md",
   "readings/2022-07-11-clean-craftsmanship.md",

--- a/content/readings/2016-08-01-the-clean-coder.md
+++ b/content/readings/2016-08-01-the-clean-coder.md
@@ -9,7 +9,6 @@ subtitle = "A Code of Conduct for Professional Programmers"
 pages = "250"
 author = "Robert C. Martin"
 static_thumbnail = "/images/readings/the-clean-coder.webp"
-expand_preview = true
 related_readings = [
   "readings/2016-05-01-clean-code.md",
   "readings/2022-07-11-clean-craftsmanship.md",

--- a/content/readings/2016-09-01-sprint.es.md
+++ b/content/readings/2016-09-01-sprint.es.md
@@ -9,7 +9,6 @@ subtitle = "Cómo resolver grandes problemas y probar nuevas ideas en solo cinco
 pages = "280"
 author = "Jake Knapp, John Zeratsky, Braden Kowitz"
 static_thumbnail = "/images/readings/sprint.webp"
-expand_preview = false
 related_readings = [
   "readings/2020-06-10-scrum-the-art-of-doing-twice.md",
   "readings/2022-08-21-continuous-discovery-habits.md",

--- a/content/readings/2016-09-01-sprint.md
+++ b/content/readings/2016-09-01-sprint.md
@@ -9,7 +9,6 @@ subtitle = "How to Solve Big Problems and Test New Ideas in Just Five Days"
 pages = "280"
 author = "Jake Knapp, John Zeratsky, Braden Kowitz"
 static_thumbnail = "/images/readings/sprint.webp"
-expand_preview = false
 related_readings = [
   "readings/2020-06-10-scrum-the-art-of-doing-twice.md",
   "readings/2022-08-21-continuous-discovery-habits.md",

--- a/content/readings/2018-08-10-the-art-of-war.es.md
+++ b/content/readings/2018-08-10-the-art-of-war.es.md
@@ -9,7 +9,6 @@ subtitle = "¿Cómo debemos comportarnos en una batalla?"
 pages = "100"
 author = "Sun Tzu"
 static_thumbnail = "/images/readings/the-art-of-war.webp"
-expand_preview = false
 related_readings = [
   "readings/2021-04-19-the-art-of-leadership.md",
   "readings/2021-11-28-start-with-why.md",

--- a/content/readings/2018-08-10-the-art-of-war.md
+++ b/content/readings/2018-08-10-the-art-of-war.md
@@ -9,7 +9,6 @@ subtitle = "How should we behave in a battle?"
 pages = "100"
 author = "Sun Tzu"
 static_thumbnail = "/images/readings/the-art-of-war.webp"
-expand_preview = false
 related_readings = [
   "readings/2021-04-19-the-art-of-leadership.md",
   "readings/2021-11-28-start-with-why.md",

--- a/content/readings/2020-08-16-advance-web-application-architecture.es.md
+++ b/content/readings/2020-08-16-advance-web-application-architecture.es.md
@@ -9,7 +9,6 @@ subtitle = "La guía que lleva tus habilidades de código al siguiente nivel"
 pages = "370"
 author = "Matthias Noback"
 static_thumbnail = "/images/readings/advance-web-application-architecture.webp"
-expand_preview = true
 related_readings = [
   "readings/2018-06-04-clean-architecture.md",
   "readings/2020-09-10-domain-driven-design-distilled.md",

--- a/content/readings/2020-08-16-advance-web-application-architecture.md
+++ b/content/readings/2020-08-16-advance-web-application-architecture.md
@@ -9,7 +9,6 @@ subtitle = "The best guide that brings your coding skills a level up."
 pages = "370"
 author = "Matthias Noback"
 static_thumbnail = "/images/readings/advance-web-application-architecture.webp"
-expand_preview = true
 related_readings = [
   "readings/2018-06-04-clean-architecture.md",
   "readings/2020-09-10-domain-driven-design-distilled.md",

--- a/content/readings/2020-09-10-domain-driven-design-distilled.es.md
+++ b/content/readings/2020-09-10-domain-driven-design-distilled.es.md
@@ -9,7 +9,6 @@ subtitle = "DDD explicado de forma clara y práctica"
 pages = "160"
 author = "Vaughn Vernon"
 static_thumbnail = "/images/readings/domain-driven-design-distilled.webp"
-expand_preview = true
 related_readings = [
   "readings/2018-06-04-clean-architecture.md",
   "readings/2022-11-28-recipes-for-decoupling.md",

--- a/content/readings/2020-09-10-domain-driven-design-distilled.md
+++ b/content/readings/2020-09-10-domain-driven-design-distilled.md
@@ -9,7 +9,6 @@ subtitle = ""
 pages = "160"
 author = "Vaughn Vernon"
 static_thumbnail = "/images/readings/domain-driven-design-distilled.webp"
-expand_preview = true
 related_readings = [
   "readings/2018-06-04-clean-architecture.md",
   "readings/2022-11-28-recipes-for-decoupling.md",

--- a/content/readings/2020-10-10-object-design-style-guide.es.md
+++ b/content/readings/2020-10-10-object-design-style-guide.es.md
@@ -9,7 +9,6 @@ description = "Técnicas para escribir código orientado a objetos flexible, leg
 pages = "240"
 author = "Matthias Noback"
 static_thumbnail = "/images/readings/object-design-style-guide.webp"
-expand_preview = true
 related_readings = [
   "readings/2016-05-01-clean-code.md",
   "readings/2020-09-10-domain-driven-design-distilled.md",

--- a/content/readings/2020-10-10-object-design-style-guide.md
+++ b/content/readings/2020-10-10-object-design-style-guide.md
@@ -9,7 +9,6 @@ subtitle = "Powerful Techniques for Creating Flexible, Readable, and Maintainabl
 pages = "240"
 author = "Matthias Noback"
 static_thumbnail = "/images/readings/object-design-style-guide.webp"
-expand_preview = true
 related_readings = [
   "readings/2016-05-01-clean-code.md",
   "readings/2020-09-10-domain-driven-design-distilled.md",

--- a/content/readings/2021-01-16-who-moved-my-cheese.es.md
+++ b/content/readings/2021-01-16-who-moved-my-cheese.es.md
@@ -9,7 +9,6 @@ subtitle = "Una forma sorprendente de afrontar el cambio en el trabajo y en la v
 pages = "94"
 author = "Spencer Johnson"
 static_thumbnail = "/images/readings/who-moved-my-cheese.webp"
-expand_preview = true
 related_posts = ["blog/2021-03-01-embrace-the-change.md"]
 related_readings = [
   "readings/2019-11-12-atomic-habits.md",

--- a/content/readings/2021-01-16-who-moved-my-cheese.md
+++ b/content/readings/2021-01-16-who-moved-my-cheese.md
@@ -9,7 +9,6 @@ subtitle = "An Amazing Way to Deal With Change In Your Work and In Your Life"
 pages = "94"
 author = "Spencer Johnson"
 static_thumbnail = "/images/readings/who-moved-my-cheese.webp"
-expand_preview = true
 related_posts = ["blog/2021-03-01-embrace-the-change.md"]
 related_readings = [
   "readings/2019-11-12-atomic-habits.md",

--- a/content/readings/2021-05-28-peopleware.es.md
+++ b/content/readings/2021-05-28-peopleware.es.md
@@ -9,7 +9,6 @@ subtitle = "Proyectos y equipos productivos"
 pages = "230"
 author = "Tom DeMarco"
 static_thumbnail = "/images/readings/peopleware.webp"
-expand_preview = true
 related_readings = [
   "readings/2022-03-31-team-topologies.md",
   "readings/2021-12-07-the-five-dysfunctions-of-a-team.md",

--- a/content/readings/2021-05-28-peopleware.md
+++ b/content/readings/2021-05-28-peopleware.md
@@ -9,7 +9,6 @@ subtitle = "Productive Projects and Teams"
 pages = "230"
 author = "Tom DeMarco"
 static_thumbnail = "/images/readings/peopleware.webp"
-expand_preview = true
 related_readings = [
   "readings/2022-03-31-team-topologies.md",
   "readings/2021-12-07-the-five-dysfunctions-of-a-team.md",

--- a/content/readings/2021-06-27-effective-software-em.es.md
+++ b/content/readings/2021-06-27-effective-software-em.es.md
@@ -9,7 +9,6 @@ subtitle = "Cómo ser el líder que tu equipo de desarrollo necesita"
 pages = "350"
 author = "James Stanier"
 static_thumbnail = "/images/readings/effective-software-em.webp"
-expand_preview = true
 related_readings = [
   "readings/2020-03-26-the-manager-path.md",
   "readings/2020-04-03-high-output-management.md",

--- a/content/readings/2021-06-27-effective-software-em.md
+++ b/content/readings/2021-06-27-effective-software-em.md
@@ -9,7 +9,6 @@ subtitle = "How to Be the Leader Your Development Team Needs"
 pages = "350"
 author = "James Stanier"
 static_thumbnail = "/images/readings/effective-software-em.webp"
-expand_preview = true
 related_readings = [
   "readings/2020-03-26-the-manager-path.md",
   "readings/2020-04-03-high-output-management.md",

--- a/content/readings/2021-07-10-lord-of-the-flies.es.md
+++ b/content/readings/2021-07-10-lord-of-the-flies.es.md
@@ -9,7 +9,6 @@ subtitle = ""
 pages = "220"
 author = "William Golding"
 static_thumbnail = "/images/readings/lord-of-the-flies.webp"
-expand_preview = true
 related_readings = [
   "readings/2020-11-02-animal-farm.md",
   "readings/2020-05-13-1984.md",

--- a/content/readings/2021-07-10-lord-of-the-flies.md
+++ b/content/readings/2021-07-10-lord-of-the-flies.md
@@ -9,7 +9,6 @@ subtitle = ""
 pages = "220"
 author = "William Golding"
 static_thumbnail = "/images/readings/lord-of-the-flies.webp"
-expand_preview = true
 related_readings = [
   "readings/2020-11-02-animal-farm.md",
   "readings/2020-05-13-1984.md",

--- a/content/readings/2021-08-08-the-catcher-in-the-rye.es.md
+++ b/content/readings/2021-08-08-the-catcher-in-the-rye.es.md
@@ -9,7 +9,6 @@ subtitle = ""
 pages = "220"
 author = "J. D. Salinger"
 static_thumbnail = "/images/readings/the-catcher-in-the-rye.webp"
-expand_preview = false
 related_readings = [
   "readings/2026-02-04-notes-from-underground.md",
   "readings/2021-07-10-lord-of-the-flies.md",

--- a/content/readings/2021-08-08-the-catcher-in-the-rye.md
+++ b/content/readings/2021-08-08-the-catcher-in-the-rye.md
@@ -9,7 +9,6 @@ subtitle = ""
 pages = "220"
 author = "J. D. Salinger"
 static_thumbnail = "/images/readings/the-catcher-in-the-rye.webp"
-expand_preview = false
 related_readings = [
   "readings/2026-02-04-notes-from-underground.md",
   "readings/2021-07-10-lord-of-the-flies.md",

--- a/content/readings/2021-09-12-turn-the-ship-around.es.md
+++ b/content/readings/2021-09-12-turn-the-ship-around.es.md
@@ -9,7 +9,6 @@ subtitle = "Una historia real de convertir seguidores en líderes"
 pages = "220"
 author = "L. David Marquet"
 static_thumbnail = "/images/readings/turn-the-ship-around.webp"
-expand_preview = false
 related_readings = [
   "readings/2021-10-22-leadership-is-language.md",
   "readings/2023-09-20-its-your-ship.md",

--- a/content/readings/2021-09-12-turn-the-ship-around.md
+++ b/content/readings/2021-09-12-turn-the-ship-around.md
@@ -9,7 +9,6 @@ subtitle = "A True Story of Turning Followers into Leaders"
 pages = "220"
 author = "L. David Marquet"
 static_thumbnail = "/images/readings/turn-the-ship-around.webp"
-expand_preview = false
 related_readings = [
   "readings/2021-10-22-leadership-is-language.md",
   "readings/2023-09-20-its-your-ship.md",

--- a/content/readings/2021-09-20-the-bitcoin-standard.es.md
+++ b/content/readings/2021-09-20-the-bitcoin-standard.es.md
@@ -9,7 +9,6 @@ subtitle = "La alternativa descentralizada a la banca central"
 pages = "300"
 author = "Saifedean Ammous"
 static_thumbnail = "/images/readings/the-bitcoin-standard.webp"
-expand_preview = false
 related_posts = [
   "blog/2025-11-21-bitcoin-fundamentals.md",
   "blog/2025-12-22-how-bitcoin-works.md",

--- a/content/readings/2021-09-20-the-bitcoin-standard.md
+++ b/content/readings/2021-09-20-the-bitcoin-standard.md
@@ -9,7 +9,6 @@ subtitle = "The Decentralized Alternative to Central Banking"
 pages = "300"
 author = "Saifedean Ammous"
 static_thumbnail = "/images/readings/the-bitcoin-standard.webp"
-expand_preview = false
 related_readings = [
   "readings/2023-06-20-the-blocksize-war.md",
   "readings/2023-07-10-the-book-of-satoshi.md",

--- a/content/readings/2021-10-22-leadership-is-language.es.md
+++ b/content/readings/2021-10-22-leadership-is-language.es.md
@@ -9,7 +9,6 @@ subtitle = "El poder oculto de lo que dices, y lo que no"
 pages = "350"
 author = "L. David Marquet"
 static_thumbnail = "/images/readings/leadership-is-language.webp"
-expand_preview = true
 related_readings = [
   "readings/2021-09-12-turn-the-ship-around.md",
   "readings/2024-04-17-radical-candor.md",

--- a/content/readings/2021-10-22-leadership-is-language.md
+++ b/content/readings/2021-10-22-leadership-is-language.md
@@ -9,7 +9,6 @@ subtitle = "The hidden power of what you say, and what you don't"
 pages = "350"
 author = "L. David Marquet"
 static_thumbnail = "/images/readings/leadership-is-language.webp"
-expand_preview = true
 related_readings = [
   "readings/2021-09-12-turn-the-ship-around.md",
   "readings/2024-04-17-radical-candor.md",

--- a/content/readings/2021-11-28-start-with-why.es.md
+++ b/content/readings/2021-11-28-start-with-why.es.md
@@ -9,7 +9,6 @@ subtitle = "Cómo los grandes líderes inspiran a todos a actuar"
 pages = "250"
 author = "Simon Sinek"
 static_thumbnail = "/images/readings/start-with-why.webp"
-expand_preview = true
 related_readings = [
   "readings/2023-01-29-the-infinite-game.md",
   "readings/2022-01-16-leaders-eat-last.md",

--- a/content/readings/2021-11-28-start-with-why.md
+++ b/content/readings/2021-11-28-start-with-why.md
@@ -9,7 +9,6 @@ subtitle = "How Great Leaders Inspire Everyone to Take Action"
 pages = "250"
 author = "Simon Sinek"
 static_thumbnail = "/images/readings/start-with-why.webp"
-expand_preview = true
 related_readings = [
   "readings/2023-01-29-the-infinite-game.md",
   "readings/2022-01-16-leaders-eat-last.md",

--- a/content/readings/2021-12-07-the-five-dysfunctions-of-a-team.es.md
+++ b/content/readings/2021-12-07-the-five-dysfunctions-of-a-team.es.md
@@ -9,7 +9,6 @@ subtitle = "Una fábula de liderazgo"
 pages = "240"
 author = "Patrick M. Lencioni"
 static_thumbnail = "/images/readings/the-five-dysfunctions-of-a-team.webp"
-expand_preview = true
 related_readings = [
   "readings/2021-05-28-peopleware.md",
   "readings/2022-03-31-team-topologies.md",

--- a/content/readings/2021-12-07-the-five-dysfunctions-of-a-team.md
+++ b/content/readings/2021-12-07-the-five-dysfunctions-of-a-team.md
@@ -9,7 +9,6 @@ subtitle = "A Leadership Fable"
 pages = "240"
 author = "Patrick M. Lencioni"
 static_thumbnail = "/images/readings/the-five-dysfunctions-of-a-team.webp"
-expand_preview = true
 related_readings = [
   "readings/2021-05-28-peopleware.md",
   "readings/2022-03-31-team-topologies.md",

--- a/content/readings/2022-01-08-jonathan-livingston-seagull.es.md
+++ b/content/readings/2022-01-08-jonathan-livingston-seagull.es.md
@@ -9,7 +9,6 @@ subtitle = "Una historia"
 pages = "100"
 author = "Richard Bach"
 static_thumbnail = "/images/readings/jonathan-livingston-seagull.webp"
-expand_preview = false
 related_readings = [
   "readings/2023-11-07-the-alchemist.md",
   "readings/2022-12-17-momo.md",

--- a/content/readings/2022-01-08-jonathan-livingston-seagull.md
+++ b/content/readings/2022-01-08-jonathan-livingston-seagull.md
@@ -9,7 +9,6 @@ subtitle = "A story"
 pages = "100"
 author = "Richard Bach"
 static_thumbnail = "/images/readings/jonathan-livingston-seagull.webp"
-expand_preview = false
 related_readings = [
   "readings/2023-11-07-the-alchemist.md",
   "readings/2022-12-17-momo.md",

--- a/content/readings/2022-01-16-leaders-eat-last.es.md
+++ b/content/readings/2022-01-16-leaders-eat-last.es.md
@@ -9,7 +9,6 @@ subtitle = "Por qué algunos equipos trabajan unidos y otros no"
 pages = "360"
 author = "Simon Sinek"
 static_thumbnail = "/images/readings/leaders-eat-last.webp"
-expand_preview = false
 related_readings = [
   "readings/2021-11-28-start-with-why.md",
   "readings/2022-09-30-dare-to-lead.md",

--- a/content/readings/2022-01-16-leaders-eat-last.md
+++ b/content/readings/2022-01-16-leaders-eat-last.md
@@ -9,7 +9,6 @@ subtitle = "Why Some Teams Pull Together and Others Don't"
 pages = "360"
 author = "Simon Sinek"
 static_thumbnail = "/images/readings/leaders-eat-last.webp"
-expand_preview = false
 related_readings = [
   "readings/2021-11-28-start-with-why.md",
   "readings/2022-09-30-dare-to-lead.md",

--- a/content/readings/2022-01-23-modern-cto.es.md
+++ b/content/readings/2022-01-23-modern-cto.es.md
@@ -9,7 +9,6 @@ subtitle = ""
 pages = "144"
 author = "Joel Beasley"
 static_thumbnail = "/images/readings/modern-cto.webp"
-expand_preview = false
 related_readings = [
   "readings/2021-11-28-start-with-why.md",
   "readings/2020-03-26-the-manager-path.md",

--- a/content/readings/2022-01-23-modern-cto.md
+++ b/content/readings/2022-01-23-modern-cto.md
@@ -9,7 +9,6 @@ subtitle = ""
 pages = "144"
 author = "Joel Beasley"
 static_thumbnail = "/images/readings/modern-cto.webp"
-expand_preview = false
 related_readings = [
   "readings/2021-11-28-start-with-why.md",
   "readings/2020-03-26-the-manager-path.md",

--- a/content/readings/2022-02-27-the-psychology-of-money.es.md
+++ b/content/readings/2022-02-27-the-psychology-of-money.es.md
@@ -9,7 +9,6 @@ subtitle = "Lecciones sobre riqueza, codicia y felicidad"
 pages = "240"
 author = "Morgan Housel"
 static_thumbnail = "/images/readings/the-psychology-of-money.webp"
-expand_preview = false
 related_readings = [
   "readings/2021-01-15-rich-dad-poor-dad.md",
   "readings/2021-09-20-the-bitcoin-standard.md",

--- a/content/readings/2022-02-27-the-psychology-of-money.md
+++ b/content/readings/2022-02-27-the-psychology-of-money.md
@@ -9,7 +9,6 @@ subtitle = "Timeless Lessons on Wealth, Greed, and Happiness by Morgan Housel"
 pages = "240"
 author = "Morgan Housel"
 static_thumbnail = "/images/readings/the-psychology-of-money.webp"
-expand_preview = false
 related_readings = [
   "readings/2021-01-15-rich-dad-poor-dad.md",
   "readings/2021-09-20-the-bitcoin-standard.md",

--- a/content/readings/2022-03-31-team-topologies.es.md
+++ b/content/readings/2022-03-31-team-topologies.es.md
@@ -9,7 +9,6 @@ subtitle = "Organizando equipos de negocio y tecnología para flujo rápido"
 pages = "240"
 author = "Matthew Skelton, Manuel Pais"
 static_thumbnail = "/images/readings/team-topologies.webp"
-expand_preview = false
 related_posts = [
   "blog/2022-04-02-dunbar-number.md",
 ]

--- a/content/readings/2022-03-31-team-topologies.md
+++ b/content/readings/2022-03-31-team-topologies.md
@@ -9,7 +9,6 @@ subtitle = "Organizing Business and Technology Teams for Fast Flow"
 pages = "240"
 author = "Matthew Skelton, Manuel Pais"
 static_thumbnail = "/images/readings/team-topologies.webp"
-expand_preview = false
 related_posts = [
   "blog/2022-04-02-dunbar-number.md",
 ]

--- a/content/readings/2022-04-29-docker-secdevops.es.md
+++ b/content/readings/2022-04-29-docker-secdevops.es.md
@@ -9,7 +9,6 @@ subtitle = "Desde introducción hasta conceptos avanzados"
 pages = "200"
 author = "Fran Ramírez, Elías Grande, Rafael Troncoso"
 static_thumbnail = "/images/readings/docker-secdevops.webp"
-expand_preview = false
 related_readings = [
   "readings/2024-05-31-the-phoenix-project.md",
   "readings/2023-03-19-accelerate.md",

--- a/content/readings/2022-04-29-docker-secdevops.md
+++ b/content/readings/2022-04-29-docker-secdevops.md
@@ -9,7 +9,6 @@ subtitle = "From introduction to advanced concepts"
 pages = "200"
 author = "Fran Ramírez, Elías Grande, Rafael Troncoso"
 static_thumbnail = "/images/readings/docker-secdevops.webp"
-expand_preview = false
 related_readings = [
   "readings/2024-05-31-the-phoenix-project.md",
   "readings/2023-03-19-accelerate.md",

--- a/content/readings/2022-05-10-bitcoin-la-tecnologia-blockchain-y-su-investigacion.es.md
+++ b/content/readings/2022-05-10-bitcoin-la-tecnologia-blockchain-y-su-investigacion.es.md
@@ -10,7 +10,6 @@ subtitle = "Publicado en 2017, la mayor parte de la tecnología mostrada ya es h
 pages = "200"
 author = "Félix Brezo, Yaiza Rubio"
 static_thumbnail = "/images/readings/bitcoin-la-tecnologia-blockchain-y-su-investigacion.webp"
-expand_preview = false
 related_readings = [
   "readings/2021-09-20-the-bitcoin-standard.md",
   "readings/2024-07-05-mastering-bitcoin.md",

--- a/content/readings/2022-05-10-bitcoin-la-tecnologia-blockchain-y-su-investigacion.md
+++ b/content/readings/2022-05-10-bitcoin-la-tecnologia-blockchain-y-su-investigacion.md
@@ -10,7 +10,6 @@ subtitle = "Published in 2017, most of the technology shown is already history"
 pages = "200"
 author = "Félix Brezo, Yaiza Rubio"
 static_thumbnail = "/images/readings/bitcoin-la-tecnologia-blockchain-y-su-investigacion.webp"
-expand_preview = false
 related_readings = [
   "readings/2021-09-20-the-bitcoin-standard.md",
   "readings/2024-07-05-mastering-bitcoin.md",

--- a/content/readings/2022-06-29-modern-software-engineering.es.md
+++ b/content/readings/2022-06-29-modern-software-engineering.es.md
@@ -9,7 +9,6 @@ subtitle = "Haciendo lo que funciona para construir mejor software más rápido"
 pages = "200"
 author = "David Farley"
 static_thumbnail = "/images/readings/modern-software-engineering.webp"
-expand_preview = false
 related_readings = [
   "readings/2022-07-11-clean-craftsmanship.md",
   "readings/2023-03-19-accelerate.md",

--- a/content/readings/2022-06-29-modern-software-engineering.md
+++ b/content/readings/2022-06-29-modern-software-engineering.md
@@ -9,7 +9,6 @@ subtitle = "Doing What Works to Build Better Software Faster"
 pages = "200"
 author = "David Farley"
 static_thumbnail = "/images/readings/modern-software-engineering.webp"
-expand_preview = false
 related_readings = [
   "readings/2022-07-11-clean-craftsmanship.md",
   "readings/2023-03-19-accelerate.md",

--- a/content/readings/2022-07-11-clean-craftsmanship.es.md
+++ b/content/readings/2022-07-11-clean-craftsmanship.es.md
@@ -9,7 +9,6 @@ subtitle = "Disciplinas, Estándares y Ética"
 pages = "380"
 author = "Robert C. Martin"
 static_thumbnail = "/images/readings/clean-craftsmanship.webp"
-expand_preview = false
 related_posts = [
   "blog/2021-08-01-test-driven-development.md",
   "blog/2024-03-28-effective-pair-programming.md",

--- a/content/readings/2022-07-11-clean-craftsmanship.md
+++ b/content/readings/2022-07-11-clean-craftsmanship.md
@@ -9,7 +9,6 @@ subtitle = "Disciplines, Standards, and Ethics"
 pages = "380"
 author = "Robert C. Martin"
 static_thumbnail = "/images/readings/clean-craftsmanship.webp"
-expand_preview = false
 related_posts = [
   "blog/2021-08-01-test-driven-development.md",
   "blog/2024-03-28-effective-pair-programming.md",

--- a/content/readings/2022-07-19-the-starfish-and-the-spider.es.md
+++ b/content/readings/2022-07-19-the-starfish-and-the-spider.es.md
@@ -10,7 +10,6 @@ subtitle = "El poder imparable de las organizaciones sin líder"
 pages = "240"
 author = "Ori Brafman, Rod Beckstrom"
 static_thumbnail = "/images/readings/the-starfish-and-the-spider.webp"
-expand_preview = false
 related_readings = [
   "readings/2022-08-01-the-great-ceo-within.md",
   "readings/2022-10-29-the-essential-drucker.md",

--- a/content/readings/2022-07-19-the-starfish-and-the-spider.md
+++ b/content/readings/2022-07-19-the-starfish-and-the-spider.md
@@ -10,7 +10,6 @@ subtitle = "The Unstoppable Power of Leaderless Organizations"
 pages = "240"
 author = "Ori Brafman, Rod Beckstrom"
 static_thumbnail = "/images/readings/the-starfish-and-the-spider.webp"
-expand_preview = false
 related_readings = [
   "readings/2022-08-01-the-great-ceo-within.md",
   "readings/2022-10-29-the-essential-drucker.md",

--- a/content/readings/2022-08-01-the-great-ceo-within.es.md
+++ b/content/readings/2022-08-01-the-great-ceo-within.es.md
@@ -9,7 +9,6 @@ subtitle = "La guía táctica para construir empresas"
 pages = "200"
 author = "Matt Mochary"
 static_thumbnail = "/images/readings/the-great-ceo-within.webp"
-expand_preview = false
 related_readings = [
   "readings/2020-04-03-high-output-management.md",
   "readings/2022-10-29-the-essential-drucker.md",

--- a/content/readings/2022-08-01-the-great-ceo-within.md
+++ b/content/readings/2022-08-01-the-great-ceo-within.md
@@ -9,7 +9,6 @@ subtitle = "The Tactical Guide to Company Building"
 pages = "200"
 author = "Matt Mochary"
 static_thumbnail = "/images/readings/the-great-ceo-within.webp"
-expand_preview = false
 related_readings = [
   "readings/2020-04-03-high-output-management.md",
   "readings/2022-10-29-the-essential-drucker.md",

--- a/content/readings/2022-08-21-continuous-discovery-habits.es.md
+++ b/content/readings/2022-08-21-continuous-discovery-habits.es.md
@@ -9,7 +9,6 @@ subtitle = "Descubre Productos que Crean Valor para el Cliente y Valor de Negoci
 pages = "220"
 author = "Teresa Torres"
 static_thumbnail = "/images/readings/continuous-discovery-habits.webp"
-expand_preview = false
 related_readings = [
   "readings/2024-01-26-the-lean-startup.md",
   "readings/2016-09-01-sprint.md",

--- a/content/readings/2022-08-21-continuous-discovery-habits.md
+++ b/content/readings/2022-08-21-continuous-discovery-habits.md
@@ -9,7 +9,6 @@ subtitle = "Discover Products that Create Customer Value and Business Value"
 pages = "220"
 author = "Teresa Torres"
 static_thumbnail = "/images/readings/continuous-discovery-habits.webp"
-expand_preview = false
 related_readings = [
   "readings/2024-01-26-the-lean-startup.md",
   "readings/2016-09-01-sprint.md",

--- a/content/readings/2022-09-30-dare-to-lead.es.md
+++ b/content/readings/2022-09-30-dare-to-lead.es.md
@@ -9,7 +9,6 @@ subtitle = "Trabajo Valiente. Conversaciones Difíciles. Corazones Enteros."
 pages = "320"
 author = "Brené Brown"
 static_thumbnail = "/images/readings/dare-to-lead.webp"
-expand_preview = false
 related_readings = [
   "readings/2024-04-17-radical-candor.md",
   "readings/2022-01-16-leaders-eat-last.md",

--- a/content/readings/2022-09-30-dare-to-lead.md
+++ b/content/readings/2022-09-30-dare-to-lead.md
@@ -9,7 +9,6 @@ subtitle = "Brave Work. Tough Conversations. Whole Hearts."
 pages = "320"
 author = "Brené Brown"
 static_thumbnail = "/images/readings/dare-to-lead.webp"
-expand_preview = false
 related_readings = [
   "readings/2024-04-17-radical-candor.md",
   "readings/2022-01-16-leaders-eat-last.md",

--- a/content/readings/2022-10-29-the-essential-drucker.es.md
+++ b/content/readings/2022-10-29-the-essential-drucker.es.md
@@ -9,7 +9,6 @@ subtitle = "Lo Mejor de Sesenta Años de Escritos de Peter Drucker sobre Gestió
 pages = "360"
 author = "Peter F. Drucker"
 static_thumbnail = "/images/readings/the-essential-drucker.webp"
-expand_preview = false
 related_readings = [
   "readings/2020-04-03-high-output-management.md",
   "readings/2022-08-01-the-great-ceo-within.md",

--- a/content/readings/2022-10-29-the-essential-drucker.md
+++ b/content/readings/2022-10-29-the-essential-drucker.md
@@ -9,7 +9,6 @@ subtitle = "The Best of Sixty Years of Peter Drucker's Essential Writings on Man
 pages = "360"
 author = "Peter F. Drucker"
 static_thumbnail = "/images/readings/the-essential-drucker.webp"
-expand_preview = false
 related_readings = [
   "readings/2020-04-03-high-output-management.md",
   "readings/2022-08-01-the-great-ceo-within.md",

--- a/content/readings/2022-11-28-recipes-for-decoupling.es.md
+++ b/content/readings/2022-11-28-recipes-for-decoupling.es.md
@@ -9,7 +9,6 @@ subtitle = ""
 pages = "280"
 author = "Matthias Noback"
 static_thumbnail = "/images/readings/recipes-for-decoupling.webp"
-expand_preview = false
 related_readings = [
   "readings/2018-06-04-clean-architecture.md",
   "readings/2020-09-10-domain-driven-design-distilled.md",

--- a/content/readings/2022-11-28-recipes-for-decoupling.md
+++ b/content/readings/2022-11-28-recipes-for-decoupling.md
@@ -9,7 +9,6 @@ subtitle = ""
 pages = "280"
 author = "Matthias Noback"
 static_thumbnail = "/images/readings/recipes-for-decoupling.webp"
-expand_preview = false
 related_readings = [
   "readings/2018-06-04-clean-architecture.md",
   "readings/2020-09-10-domain-driven-design-distilled.md",

--- a/content/readings/2022-12-17-momo.es.md
+++ b/content/readings/2022-12-17-momo.es.md
@@ -10,7 +10,6 @@ subtitle = "O la extraña historia de los ladrones de tiempo y la niña que devo
 pages = "250"
 author = "Michael Ende"
 static_thumbnail = "/images/readings/momo.webp"
-expand_preview = true
 related_readings = [
   "readings/2023-11-07-the-alchemist.md",
   "readings/2022-01-08-jonathan-livingston-seagull.md",

--- a/content/readings/2022-12-17-momo.md
+++ b/content/readings/2022-12-17-momo.md
@@ -10,7 +10,6 @@ subtitle = "Or the strange story of the time-thieves and the child who brought t
 pages = "250"
 author = "Michael Ende"
 static_thumbnail = "/images/readings/momo.webp"
-expand_preview = true
 related_readings = [
   "readings/2023-11-07-the-alchemist.md",
   "readings/2022-01-08-jonathan-livingston-seagull.md",

--- a/content/readings/2023-01-29-the-infinite-game.es.md
+++ b/content/readings/2023-01-29-the-infinite-game.es.md
@@ -9,7 +9,6 @@ subtitle = "Un marco para el liderazgo en un mundo que cambia constantemente"
 pages = "270"
 author = "Simon Sinek"
 static_thumbnail = "/images/readings/the-infinite-game.webp"
-expand_preview = true
 related_readings = [
   "readings/2021-11-28-start-with-why.md",
   "readings/2022-01-16-leaders-eat-last.md",

--- a/content/readings/2023-01-29-the-infinite-game.md
+++ b/content/readings/2023-01-29-the-infinite-game.md
@@ -9,7 +9,6 @@ subtitle = "A bold framework for leadership in today's ever-changing world"
 pages = "270"
 author = "Simon Sinek"
 static_thumbnail = "/images/readings/the-infinite-game.webp"
-expand_preview = true
 related_readings = [
   "readings/2021-11-28-start-with-why.md",
   "readings/2022-01-16-leaders-eat-last.md",

--- a/content/readings/2023-02-26-adapt-or-die.es.md
+++ b/content/readings/2023-02-26-adapt-or-die.es.md
@@ -10,7 +10,6 @@ subtitle = "Cómo Crear Innovación, Resolver Puzzles de Personas y Ganar en los
 pages = "270"
 author = "Thomas H. Douglas"
 static_thumbnail = "/images/readings/adapt-or-die.webp"
-expand_preview = true
 related_readings = [
   "readings/2021-01-16-who-moved-my-cheese.md",
   "readings/2023-01-29-the-infinite-game.md",

--- a/content/readings/2023-02-26-adapt-or-die.md
+++ b/content/readings/2023-02-26-adapt-or-die.md
@@ -10,7 +10,6 @@ subtitle = "How to Create Innovation, Solve People Puzzles, and Win in Business"
 pages = "270"
 author = "Thomas H. Douglas"
 static_thumbnail = "/images/readings/adapt-or-die.webp"
-expand_preview = true
 related_readings = [
   "readings/2021-01-16-who-moved-my-cheese.md",
   "readings/2023-01-29-the-infinite-game.md",

--- a/content/readings/2023-03-11-21-lessons.es.md
+++ b/content/readings/2023-03-11-21-lessons.es.md
@@ -10,7 +10,6 @@ subtitle = "Lo Que He Aprendido al Caer por la Madriguera del Conejo de Bitcoin"
 pages = "150"
 author = "Gigi"
 static_thumbnail = "/images/readings/21-lessons.webp"
-expand_preview = true
 related_readings = [
   "readings/2021-09-20-the-bitcoin-standard.md",
   "readings/2023-07-10-the-book-of-satoshi.md",

--- a/content/readings/2023-03-11-21-lessons.md
+++ b/content/readings/2023-03-11-21-lessons.md
@@ -10,7 +10,6 @@ subtitle = "What I've Learned from Falling Down the Bitcoin Rabbit Hole"
 pages = "150"
 author = "Gigi"
 static_thumbnail = "/images/readings/21-lessons.webp"
-expand_preview = true
 related_readings = [
   "readings/2021-09-20-the-bitcoin-standard.md",
   "readings/2023-07-10-the-book-of-satoshi.md",

--- a/content/readings/2023-03-19-accelerate.es.md
+++ b/content/readings/2023-03-19-accelerate.es.md
@@ -10,7 +10,6 @@ subtitle = "Construyendo y Escalando Organizaciones Tecnológicas de Alto Rendim
 pages = "150"
 author = "Nicole Forsgren, Jez Humble, Gene Kim"
 static_thumbnail = "/images/readings/accelerate.webp"
-expand_preview = false
 related_readings = [
   "readings/2024-05-31-the-phoenix-project.md",
   "readings/2022-03-31-team-topologies.md",

--- a/content/readings/2023-03-19-accelerate.md
+++ b/content/readings/2023-03-19-accelerate.md
@@ -10,7 +10,6 @@ subtitle = "Building and Scaling High Performing Technology Organizations"
 pages = "150"
 author = "Nicole Forsgren, Jez Humble, Gene Kim"
 static_thumbnail = "/images/readings/accelerate.webp"
-expand_preview = false
 related_readings = [
   "readings/2024-05-31-the-phoenix-project.md",
   "readings/2022-03-31-team-topologies.md",

--- a/content/readings/2023-04-17-effective-remote-work.es.md
+++ b/content/readings/2023-04-17-effective-remote-work.es.md
@@ -10,7 +10,6 @@ subtitle = "Para Ti, Tu Equipo y Tu Empresa"
 pages = "300"
 author = "James Stanier"
 static_thumbnail = "/images/readings/effective-remote-work.webp"
-expand_preview = false
 related_readings = [
   "readings/2021-05-28-peopleware.md",
   "readings/2022-03-31-team-topologies.md",

--- a/content/readings/2023-04-17-effective-remote-work.md
+++ b/content/readings/2023-04-17-effective-remote-work.md
@@ -10,7 +10,6 @@ subtitle = "For Yourself, Your Team, and Your Company"
 pages = "300"
 author = "James Stanier"
 static_thumbnail = "/images/readings/effective-remote-work.webp"
-expand_preview = false
 related_readings = [
   "readings/2021-05-28-peopleware.md",
   "readings/2022-03-31-team-topologies.md",

--- a/content/readings/2023-05-31-agile-project-management.es.md
+++ b/content/readings/2023-05-31-agile-project-management.es.md
@@ -10,7 +10,6 @@ subtitle = "Una Guía para Principiantes sobre Implementación y Liderazgo Ágil
 pages = "120"
 author = "Jeremy Savell"
 static_thumbnail = "/images/readings/agile-project-management.webp"
-expand_preview = false
 related_posts = ["blog/2022-11-11-working-agile-with-non-agile-teams.md", "blog/2022-12-06-ignoring-scrum-to-get-more-agile.md", "blog/2023-01-09-interview-about-xp-and-agile.md"]
 related_readings = [
   "readings/2020-06-10-scrum-the-art-of-doing-twice.md",

--- a/content/readings/2023-05-31-agile-project-management.md
+++ b/content/readings/2023-05-31-agile-project-management.md
@@ -10,7 +10,6 @@ subtitle = "A Beginner's Guide to Agile Implementation and Leadership"
 pages = "120"
 author = "Jeremy Savell"
 static_thumbnail = "/images/readings/agile-project-management.webp"
-expand_preview = false
 related_posts = ["blog/2022-11-11-working-agile-with-non-agile-teams.md", "blog/2022-12-06-ignoring-scrum-to-get-more-agile.md", "blog/2023-01-09-interview-about-xp-and-agile.md"]
 related_readings = [
   "readings/2020-06-10-scrum-the-art-of-doing-twice.md",

--- a/content/readings/2023-06-20-the-blocksize-war.es.md
+++ b/content/readings/2023-06-20-the-blocksize-war.es.md
@@ -10,7 +10,6 @@ subtitle = "La batalla por el control del protocolo de Bitcoin"
 pages = "240"
 author = "Jonathan Bier"
 static_thumbnail = "/images/readings/the-blocksize-war.webp"
-expand_preview = false
 related_readings = [
   "readings/2021-09-20-the-bitcoin-standard.md",
   "readings/2023-07-10-the-book-of-satoshi.md",

--- a/content/readings/2023-06-20-the-blocksize-war.md
+++ b/content/readings/2023-06-20-the-blocksize-war.md
@@ -10,7 +10,6 @@ subtitle = "The battle for control over Bitcoin's protocol rules"
 pages = "240"
 author = "Jonathan Bier"
 static_thumbnail = "/images/readings/the-blocksize-war.webp"
-expand_preview = false
 related_readings = [
   "readings/2021-09-20-the-bitcoin-standard.md",
   "readings/2023-07-10-the-book-of-satoshi.md",

--- a/content/readings/2023-06-28-fahrenheit-451.es.md
+++ b/content/readings/2023-06-28-fahrenheit-451.es.md
@@ -10,7 +10,6 @@ subtitle = "Un clásico distópico cuyo mensaje hoy resulta más relevante que n
 pages = "180"
 author = "Ray Bradbury"
 static_thumbnail = "/images/readings/fahrenheit-451.webp"
-expand_preview = false
 related_readings = [
   "readings/2020-05-13-1984.md",
   "readings/2020-11-02-animal-farm.md",

--- a/content/readings/2023-06-28-fahrenheit-451.md
+++ b/content/readings/2023-06-28-fahrenheit-451.md
@@ -10,7 +10,6 @@ subtitle = "A classic of world literature set in a bleak, dystopian future. Toda
 pages = "180"
 author = "Ray Bradbury"
 static_thumbnail = "/images/readings/fahrenheit-451.webp"
-expand_preview = false
 related_readings = [
   "readings/2020-05-13-1984.md",
   "readings/2020-11-02-animal-farm.md",

--- a/content/readings/2023-07-10-the-book-of-satoshi.es.md
+++ b/content/readings/2023-07-10-the-book-of-satoshi.es.md
@@ -10,7 +10,6 @@ subtitle = "Los escritos del creador anónimo de Bitcoin, recopilados por primer
 pages = "350"
 author = "Phil Champagne"
 static_thumbnail = "/images/readings/the-book-of-satoshi.webp"
-expand_preview = false
 related_readings = [
   "readings/2021-09-20-the-bitcoin-standard.md",
   "readings/2023-06-20-the-blocksize-war.md",

--- a/content/readings/2023-07-10-the-book-of-satoshi.md
+++ b/content/readings/2023-07-10-the-book-of-satoshi.md
@@ -10,7 +10,6 @@ subtitle = "The Collected Writings of Bitcoin Creator Satoshi Nakamoto"
 pages = "350"
 author = "Phil Champagne"
 static_thumbnail = "/images/readings/the-book-of-satoshi.webp"
-expand_preview = false
 related_readings = [
   "readings/2021-09-20-the-bitcoin-standard.md",
   "readings/2023-06-20-the-blocksize-war.md",

--- a/content/readings/2023-08-13-the-day-of-the-triffids.es.md
+++ b/content/readings/2023-08-13-the-day-of-the-triffids.es.md
@@ -10,7 +10,6 @@ subtitle = ""
 pages = "270"
 author = "John Wyndham"
 static_thumbnail = "/images/readings/the-day-of-the-triffids.webp"
-expand_preview = true
 related_readings = [
   "readings/2020-05-18-call-of-cthulhu.md",
   "readings/2023-12-09-invincible.md",

--- a/content/readings/2023-08-13-the-day-of-the-triffids.md
+++ b/content/readings/2023-08-13-the-day-of-the-triffids.md
@@ -10,7 +10,6 @@ subtitle = ""
 pages = "270"
 author = "John Wyndham"
 static_thumbnail = "/images/readings/the-day-of-the-triffids.webp"
-expand_preview = true
 related_readings = [
   "readings/2020-05-18-call-of-cthulhu.md",
   "readings/2023-12-09-invincible.md",

--- a/content/readings/2023-09-20-its-your-ship.es.md
+++ b/content/readings/2023-09-20-its-your-ship.es.md
@@ -10,7 +10,6 @@ subtitle = "Técnicas de Gestión del Mejor Maldito Barco de la Marina"
 pages = "200"
 author = "D. Michael Abrashoff"
 static_thumbnail = "/images/readings/its-your-ship.webp"
-expand_preview = false
 related_readings = [
   "readings/2021-09-12-turn-the-ship-around.md",
   "readings/2021-10-22-leadership-is-language.md",

--- a/content/readings/2023-09-20-its-your-ship.md
+++ b/content/readings/2023-09-20-its-your-ship.md
@@ -11,7 +11,6 @@ subtitle = "Management Techniques from the Best Damn Ship in the Navy"
 pages = "200"
 author = "D. Michael Abrashoff"
 static_thumbnail = "/images/readings/its-your-ship.webp"
-expand_preview = false
 related_readings = [
   "readings/2021-09-12-turn-the-ship-around.md",
   "readings/2021-10-22-leadership-is-language.md",

--- a/content/readings/2023-10-31-crucial-conversations.es.md
+++ b/content/readings/2023-10-31-crucial-conversations.es.md
@@ -10,7 +10,6 @@ subtitle = "Herramientas para Hablar Cuando lo que Está en Juego es Alto"
 pages = "200"
 author = "Patterson, Grenny, McMillan, Switzler"
 static_thumbnail = "/images/readings/crucial-conversations.webp"
-expand_preview = false
 related_readings = [
   "readings/2020-06-12-never-split-the-difference.md",
   "readings/2024-04-17-radical-candor.md",

--- a/content/readings/2023-10-31-crucial-conversations.md
+++ b/content/readings/2023-10-31-crucial-conversations.md
@@ -10,7 +10,6 @@ subtitle = "Tools for Talking When Stakes are High"
 pages = "200"
 author = "Patterson, Grenny, McMillan, Switzler"
 static_thumbnail = "/images/readings/crucial-conversations.webp"
-expand_preview = false
 related_readings = [
   "readings/2020-06-12-never-split-the-difference.md",
   "readings/2024-04-17-radical-candor.md",

--- a/content/readings/2023-11-07-the-alchemist.es.md
+++ b/content/readings/2023-11-07-the-alchemist.es.md
@@ -10,7 +10,6 @@ subtitle = ""
 pages = "200"
 author = "Paulo Coelho"
 static_thumbnail = "/images/readings/the-alchemist.webp"
-expand_preview = false
 related_readings = [
   "readings/2022-01-08-jonathan-livingston-seagull.md",
   "readings/2022-12-17-momo.md",

--- a/content/readings/2023-11-07-the-alchemist.md
+++ b/content/readings/2023-11-07-the-alchemist.md
@@ -10,7 +10,6 @@ subtitle = ""
 pages = "200"
 author = "Paulo Coelho"
 static_thumbnail = "/images/readings/the-alchemist.webp"
-expand_preview = false
 related_readings = [
   "readings/2022-01-08-jonathan-livingston-seagull.md",
   "readings/2022-12-17-momo.md",

--- a/content/readings/2023-12-09-invincible.es.md
+++ b/content/readings/2023-12-09-invincible.es.md
@@ -10,7 +10,6 @@ subtitle = "Logra Más, Sufre Menos"
 pages = "180"
 author = "Marcos Vazquez"
 static_thumbnail = "/images/readings/invincible.webp"
-expand_preview = false
 related_posts = ["blog/2023-07-05-never-ending-loop.md", "blog/2023-03-16-have-you-always-been-like-this.md", "blog/2020-09-08-the-process-itself-is-the-goal.md"]
 related_readings = [
   "readings/2023-08-13-the-day-of-the-triffids.md",

--- a/content/readings/2023-12-09-invincible.md
+++ b/content/readings/2023-12-09-invincible.md
@@ -10,7 +10,6 @@ subtitle = "Achieve More, Suffer Less"
 pages = "180"
 author = "Marcos Vazquez"
 static_thumbnail = "/images/readings/invincible.webp"
-expand_preview = false
 related_posts = ["blog/2023-07-05-never-ending-loop.md", "blog/2023-03-16-have-you-always-been-like-this.md", "blog/2020-09-08-the-process-itself-is-the-goal.md"]
 related_readings = [
   "readings/2023-08-13-the-day-of-the-triffids.md",

--- a/content/readings/2024-01-26-the-lean-startup.es.md
+++ b/content/readings/2024-01-26-the-lean-startup.es.md
@@ -10,7 +10,6 @@ subtitle = "Cómo los Emprendedores de Hoy Usan la Innovación Continua para Cre
 pages = "300"
 author = "Eric Ries"
 static_thumbnail = "/images/readings/the-lean-startup.webp"
-expand_preview = false
 related_posts = ["blog/2023-02-27-great-leadership.md", "blog/2022-08-22-understanding-people.md", "blog/2023-10-11-unhealthy-working-environment.md", "blog/2022-11-11-working-agile-with-non-agile-teams.md"]
 related_readings = [
   "readings/2016-09-01-sprint.md",

--- a/content/readings/2024-01-26-the-lean-startup.md
+++ b/content/readings/2024-01-26-the-lean-startup.md
@@ -10,7 +10,6 @@ subtitle = "How Today's Entrepreneurs Use Continuous Innovation to Create Radica
 pages = "300"
 author = "Eric Ries"
 static_thumbnail = "/images/readings/the-lean-startup.webp"
-expand_preview = false
 related_posts = ["blog/2023-02-27-great-leadership.md", "blog/2022-08-22-understanding-people.md", "blog/2023-10-11-unhealthy-working-environment.md", "blog/2022-11-11-working-agile-with-non-agile-teams.md"]
 related_readings = [
   "readings/2016-09-01-sprint.md",

--- a/content/readings/2024-04-17-radical-candor.es.md
+++ b/content/readings/2024-04-17-radical-candor.es.md
@@ -10,7 +10,6 @@ subtitle = "Cómo Conseguir Lo Que Quieres Diciendo Lo Que Piensas"
 pages = "300"
 author = "Kim Scott"
 static_thumbnail = "/images/readings/radical-candor.webp"
-expand_preview = false
 related_readings = [
   "readings/2023-10-31-crucial-conversations.md",
   "readings/2020-06-12-never-split-the-difference.md",

--- a/content/readings/2024-04-17-radical-candor.md
+++ b/content/readings/2024-04-17-radical-candor.md
@@ -10,7 +10,6 @@ subtitle = "How to Get What You Want by Saying What You Mean"
 pages = "300"
 author = "Kim Scott"
 static_thumbnail = "/images/readings/radical-candor.webp"
-expand_preview = false
 related_readings = [
   "readings/2023-10-31-crucial-conversations.md",
   "readings/2020-06-12-never-split-the-difference.md",

--- a/content/readings/2024-05-31-the-phoenix-project.es.md
+++ b/content/readings/2024-05-31-the-phoenix-project.es.md
@@ -10,7 +10,6 @@ subtitle = "Una Novela Sobre IT, DevOps, Y Ayudar a Tu Negocio a Ganar"
 pages = "430"
 author = "Gene Kim, Kevin Behr, George Spafford"
 static_thumbnail = "/images/readings/the-phoenix-project.webp"
-expand_preview = true
 related_posts = ["blog/2023-12-30-great-engineering.md", "blog/2023-10-11-unhealthy-working-environment.md", "blog/2024-02-25-deployments-on-fridays.md"]
 related_readings = [
   "readings/2023-03-19-accelerate.md",

--- a/content/readings/2024-05-31-the-phoenix-project.md
+++ b/content/readings/2024-05-31-the-phoenix-project.md
@@ -10,7 +10,6 @@ subtitle = "A Novel About IT, DevOps, And Helping Your Business Win"
 pages = "430"
 author = "Gene Kim, Kevin Behr, George Spafford"
 static_thumbnail = "/images/readings/the-phoenix-project.webp"
-expand_preview = true
 related_posts = ["blog/2023-12-30-great-engineering.md", "blog/2023-10-11-unhealthy-working-environment.md", "blog/2024-02-25-deployments-on-fridays.md"]
 related_readings = [
   "readings/2023-03-19-accelerate.md",

--- a/content/readings/2024-06-21-the-genesis-book.es.md
+++ b/content/readings/2024-06-21-the-genesis-book.es.md
@@ -10,7 +10,6 @@ subtitle = "La Historia de las Personas y Proyectos que Inspiraron Bitcoin"
 pages = "300"
 author = "Aaron van Wirdum"
 static_thumbnail = "/images/readings/the-genesis-book.webp"
-expand_preview = true
 related_readings = [
   "readings/2021-09-20-the-bitcoin-standard.md",
   "readings/2023-06-20-the-blocksize-war.md",

--- a/content/readings/2024-06-21-the-genesis-book.md
+++ b/content/readings/2024-06-21-the-genesis-book.md
@@ -10,7 +10,6 @@ subtitle = "The Story of the People and Projects That Inspired Bitcoin"
 pages = "300"
 author = "Aaron van Wirdum"
 static_thumbnail = "/images/readings/the-genesis-book.webp"
-expand_preview = true
 related_readings = [
   "readings/2021-09-20-the-bitcoin-standard.md",
   "readings/2023-06-20-the-blocksize-war.md",

--- a/content/readings/2024-07-05-mastering-bitcoin.es.md
+++ b/content/readings/2024-07-05-mastering-bitcoin.es.md
@@ -10,7 +10,6 @@ subtitle = "Programando la Blockchain Abierta"
 pages = "400"
 author = "Andreas M. Antonopoulos, David A. Harding"
 static_thumbnail = "/images/readings/mastering-bitcoin.webp"
-expand_preview = true
 related_posts = ["blog/2024-07-06-programmable-money.md"]
 related_readings = [
   "readings/2024-06-21-the-genesis-book.md",

--- a/content/readings/2024-07-05-mastering-bitcoin.md
+++ b/content/readings/2024-07-05-mastering-bitcoin.md
@@ -10,7 +10,6 @@ subtitle = "Programming the Open Blockchain"
 pages = "400"
 author = "Andreas M. Antonopoulos, David A. Harding"
 static_thumbnail = "/images/readings/mastering-bitcoin.webp"
-expand_preview = true
 related_posts = ["blog/2024-07-06-programmable-money.md"]
 related_readings = [
   "readings/2024-06-21-the-genesis-book.md",

--- a/content/readings/2024-08-02-bitcoin-wip.es.md
+++ b/content/readings/2024-08-02-bitcoin-wip.es.md
@@ -10,7 +10,6 @@ subtitle = "Innovaciones técnicas desde las trincheras"
 pages = "120"
 author = "Sjors Provoost"
 static_thumbnail = "/images/readings/bitcoin-wip.webp"
-expand_preview = true
 related_posts = ["blog/2024-12-11-the-cypherpunks.md", "blog/2024-07-06-programmable-money.md"]
 related_readings = [
   "readings/2021-09-20-the-bitcoin-standard.md",

--- a/content/readings/2024-08-02-bitcoin-wip.md
+++ b/content/readings/2024-08-02-bitcoin-wip.md
@@ -11,7 +11,6 @@ subtitle = "Technical innovations from the trenches"
 pages = "120"
 author = "Sjors Provoost"
 static_thumbnail = "/images/readings/bitcoin-wip.webp"
-expand_preview = true
 related_posts = ["blog/2024-12-11-the-cypherpunks.md", "blog/2024-07-06-programmable-money.md"]
 related_readings = [
   "readings/2021-09-20-the-bitcoin-standard.md",

--- a/content/readings/2024-11-29-mans-search-for-meaning.es.md
+++ b/content/readings/2024-11-29-mans-search-for-meaning.es.md
@@ -10,7 +10,6 @@ subtitle = "Propósito en la desesperación: la mirada de Frankl desde el Holoca
 pages = "120"
 author = "Viktor E. Frankl"
 static_thumbnail = "/images/readings/mans-search-for-meaning.webp"
-expand_preview = true
 related_posts = ["blog/2023-03-16-have-you-always-been-like-this.md", "blog/2020-09-08-the-process-itself-is-the-goal.md"]
 related_readings = [
   "readings/2026-02-04-notes-from-underground.md",

--- a/content/readings/2024-11-29-mans-search-for-meaning.md
+++ b/content/readings/2024-11-29-mans-search-for-meaning.md
@@ -10,7 +10,6 @@ subtitle = "Purpose in despair: Frankl's holocaust insights"
 pages = "120"
 author = "Viktor E. Frankl"
 static_thumbnail = "/images/readings/mans-search-for-meaning.webp"
-expand_preview = true
 related_posts = ["blog/2023-03-16-have-you-always-been-like-this.md", "blog/2020-09-08-the-process-itself-is-the-goal.md"]
 related_readings = [
   "readings/2026-02-04-notes-from-underground.md",

--- a/content/readings/2025-01-18-bitcoin-with-rigor.es.md
+++ b/content/readings/2025-01-18-bitcoin-with-rigor.es.md
@@ -10,7 +10,6 @@ subtitle = "Un estudio técnico sobre cómo funciona Bitcoin"
 pages = "520"
 author = "Jose Sanchis"
 static_thumbnail = "/images/readings/bitcoin-with-rigor.webp"
-expand_preview = true
 related_posts = ["blog/2024-12-11-the-cypherpunks.md", "blog/2024-07-06-programmable-money.md"]
 related_readings = [
   "readings/2024-07-05-mastering-bitcoin.md",

--- a/content/readings/2025-01-18-bitcoin-with-rigor.md
+++ b/content/readings/2025-01-18-bitcoin-with-rigor.md
@@ -11,7 +11,6 @@ subtitle = "A technical study about how Bitcoin works"
 pages = "520"
 author = "Jose Sanchis"
 static_thumbnail = "/images/readings/bitcoin-with-rigor.webp"
-expand_preview = true
 related_posts = ["blog/2024-12-11-the-cypherpunks.md", "blog/2024-07-06-programmable-money.md"]
 related_readings = [
   "readings/2024-07-05-mastering-bitcoin.md",

--- a/content/readings/2025-02-09-criptoria.es.md
+++ b/content/readings/2025-02-09-criptoria.es.md
@@ -10,7 +10,6 @@ subtitle = "De Turing a Nakamoto"
 pages = "250"
 author = "Alfre Mancera"
 static_thumbnail = "/images/readings/criptoria.webp"
-expand_preview = true
 related_posts = ["blog/2024-12-11-the-cypherpunks.md", "blog/2024-07-06-programmable-money.md"]
 related_readings = [
   "readings/2024-06-21-the-genesis-book.md",

--- a/content/readings/2025-02-09-criptoria.md
+++ b/content/readings/2025-02-09-criptoria.md
@@ -10,7 +10,6 @@ subtitle = "From Turing to Nakamoto"
 pages = "250"
 author = "Alfre Mancera"
 static_thumbnail = "/images/readings/criptoria.webp"
-expand_preview = true
 related_posts = ["blog/2024-12-11-the-cypherpunks.md", "blog/2024-07-06-programmable-money.md"]
 related_readings = [
   "readings/2024-06-21-the-genesis-book.md",

--- a/content/readings/2025-02-16-digital-minimalism.es.md
+++ b/content/readings/2025-02-16-digital-minimalism.es.md
@@ -10,7 +10,6 @@ subtitle = "Eligiendo una Vida Enfocada en un Mundo Ruidoso"
 pages = "250"
 author = "Cal Newport"
 static_thumbnail = "/images/readings/digital-minimalism.webp"
-expand_preview = true
 related_posts = ["blog/2020-09-08-the-process-itself-is-the-goal.md", "blog/2023-03-16-have-you-always-been-like-this.md"]
 related_readings = [
   "readings/2019-11-12-atomic-habits.md",

--- a/content/readings/2025-02-16-digital-minimalism.md
+++ b/content/readings/2025-02-16-digital-minimalism.md
@@ -10,7 +10,6 @@ subtitle = "Choosing a Focused Life in a Noisy World"
 pages = "250"
 author = "Cal Newport"
 static_thumbnail = "/images/readings/digital-minimalism.webp"
-expand_preview = true
 related_posts = ["blog/2020-09-08-the-process-itself-is-the-goal.md", "blog/2023-03-16-have-you-always-been-like-this.md"]
 related_readings = [
   "readings/2019-11-12-atomic-habits.md",

--- a/content/readings/2025-03-31-the-road-to-serfdom.es.md
+++ b/content/readings/2025-03-31-the-road-to-serfdom.es.md
@@ -10,7 +10,6 @@ subtitle = "Cómo la planificación central puede erosionar lentamente la libert
 pages = "266"
 author = "Friedrich A. Hayek"
 static_thumbnail = "/images/readings/the-road-to-serfdom.webp"
-expand_preview = true
 related_posts = ["blog/2025-01-02-understanding-taxes.md"]
 related_readings = [
   "readings/2025-06-22-principles-of-economics.md",

--- a/content/readings/2025-03-31-the-road-to-serfdom.md
+++ b/content/readings/2025-03-31-the-road-to-serfdom.md
@@ -10,7 +10,6 @@ subtitle = "How central planning can slowly erode freedom"
 pages = "266"
 author = "Friedrich A. Hayek"
 static_thumbnail = "/images/readings/the-road-to-serfdom.webp"
-expand_preview = true
 related_posts = ["blog/2025-01-02-understanding-taxes.md"]
 related_readings = [
   "readings/2025-06-22-principles-of-economics.md",

--- a/content/readings/2025-06-22-principles-of-economics.es.md
+++ b/content/readings/2025-06-22-principles-of-economics.es.md
@@ -10,7 +10,6 @@ subtitle = ""
 pages = "400"
 author = "Saifedean Ammous"
 static_thumbnail = "/images/readings/principles-of-economics.webp"
-expand_preview = true
 related_posts = ["blog/2024-12-11-the-cypherpunks.md"]
 related_readings = [
   "readings/2021-09-20-the-bitcoin-standard.md",

--- a/content/readings/2025-06-22-principles-of-economics.md
+++ b/content/readings/2025-06-22-principles-of-economics.md
@@ -10,7 +10,6 @@ subtitle = ""
 pages = "400"
 author = "Saifedean Ammous"
 static_thumbnail = "/images/readings/principles-of-economics.webp"
-expand_preview = true
 related_posts = ["blog/2024-12-11-the-cypherpunks.md"]
 related_readings = [
   "readings/2021-09-20-the-bitcoin-standard.md",

--- a/content/readings/2026-01-17-broken-money.es.md
+++ b/content/readings/2026-01-17-broken-money.es.md
@@ -10,7 +10,6 @@ subtitle = "Por qué nuestro sistema financiero nos está fallando y cómo podem
 pages = "538"
 author = "Lyn Alden"
 static_thumbnail = "/images/readings/broken-money.webp"
-expand_preview = true
 related_readings = [
   "readings/2021-09-20-the-bitcoin-standard.md",
   "readings/2024-06-21-the-genesis-book.md",

--- a/content/readings/2026-01-17-broken-money.md
+++ b/content/readings/2026-01-17-broken-money.md
@@ -10,7 +10,6 @@ subtitle = "Why Our Financial System is Failing Us and How We Can Make it Better
 pages = "538"
 author = "Lyn Alden"
 static_thumbnail = "/images/readings/broken-money.webp"
-expand_preview = true
 related_readings = [
   "readings/2021-09-20-the-bitcoin-standard.md",
   "readings/2024-06-21-the-genesis-book.md",

--- a/sass/layouts/_post.scss
+++ b/sass/layouts/_post.scss
@@ -228,11 +228,11 @@
       background: var(--search-bg-selected-item);
     }
 
-    &:hover &-label {
-      color: var(--accent-color);
-    }
-
-    &:hover &-title {
+    // `&-label` here would compile to `.blog-post__nav-link-label`, which the
+    // markup never emits: post-navigation.html uses `__nav-label`, without the
+    // `-link` infix. Spelled in full so the hover colour actually lands.
+    &:hover .blog-post__nav-label,
+    &:hover .blog-post__nav-title {
       color: var(--accent-color);
     }
 

--- a/sass/pages/_web-development.scss
+++ b/sass/pages/_web-development.scss
@@ -494,26 +494,26 @@
   }
 }
 
-// NOTE: `.pricing-card--unavailable` is never rendered, so the nested
-// `.pricing-card__badge` rule below never applies even though the badge element
-// does exist on /services/consulting/. Left in place deliberately: the styling
-// needs to be un-nested, not deleted.
 .pricing-card--unavailable {
   opacity: 0.5;
+}
 
-  .pricing-card__badge {
-    display: inline-block;
-    margin-left: 0.4rem;
-    font-size: 0.65rem;
-    font-weight: 600;
-    color: var(--color-subtitle);
-    background: var(--preview-divider-color);
-    padding: 0.2rem 0.5rem;
-    border-radius: 4px;
-    text-transform: uppercase;
-    letter-spacing: 0.03em;
-    vertical-align: middle;
-  }
+// Top level, not nested under `--unavailable`: that modifier is never rendered,
+// so the "Best value" badge on /services/consulting/ inherited the h4 it sits in
+// and showed up as plain heading text.
+.pricing-card__badge {
+  display: inline-block;
+  margin-left: 0.4rem;
+  font-size: 0.65rem;
+  font-weight: 600;
+  color: var(--accent-color);
+  background: var(--search-bg-selected-item);
+  border: 1px solid var(--accent-color);
+  padding: 0.2rem 0.5rem;
+  border-radius: 4px;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  vertical-align: middle;
 }
 
 .decision-tip {

--- a/scripts/check-topics.py
+++ b/scripts/check-topics.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""Fail the build when /topics/ does not cover every tag, or names one that is dead.
+
+templates/topics.html groups tags into the clusters listed under
+`[[extra.topics]]` in config.toml. That list is hand-maintained and the template
+fails soft in both directions:
+
+- A tag no topic mentions is dropped from the page. Nothing breaks, the tag page
+  still exists, but it is unreachable from /topics/. `ai` sat there with 22 posts,
+  the largest tag on the site, invisible.
+- A topic naming a tag no post carries renders nothing for it, so the config keeps
+  a name that means nothing. Six of those had accumulated.
+
+Both are silent, which is why they lasted. This reads config.toml and the content
+front matter directly, so it needs no build output and runs stdlib-only like the
+other checks.
+"""
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+from typing import Dict, Set
+
+ROOT = Path(__file__).resolve().parent.parent
+CONFIG = ROOT / 'config.toml'
+
+# The sections whose pages carry taxonomy tags. `services` and `music` set a
+# `tags` key too, but under [extra] on project cards, not as a taxonomy: counting
+# those invents tags that have no tag page.
+TAXONOMY_SECTIONS = ('blog', 'readings', 'talks', 'books')
+
+TOPIC_BLOCK = re.compile(r'\[\[extra\.topics\]\](.*?)(?=\n\[|\Z)', re.S)
+TAGS_LINE = re.compile(r'^tags\s*=\s*\[(.*?)\]', re.S | re.M)
+# Only the [taxonomies] table, not an [extra] tags key further down the file.
+TAXONOMIES_TABLE = re.compile(r'^\[taxonomies\]\s*\n(.*?)(?=^\[|\Z)', re.S | re.M)
+QUOTED = re.compile(r'"([^"]*)"')
+
+
+def topic_tags() -> Set[str]:
+    """Every tag named by a [[extra.topics]] cluster."""
+    config = CONFIG.read_text(encoding='utf-8')
+    tags: Set[str] = set()
+    for block in TOPIC_BLOCK.findall(config):
+        match = TAGS_LINE.search(block)
+        if match:
+            tags.update(QUOTED.findall(match.group(1)))
+    if not tags:
+        sys.exit(f'{CONFIG}: no [[extra.topics]] tags found, so /topics/ is empty')
+    return tags
+
+
+def content_tags() -> Dict[str, int]:
+    """Tag -> how many content files carry it."""
+    counts: Dict[str, int] = {}
+    for section in TAXONOMY_SECTIONS:
+        for path in (ROOT / 'content' / section).rglob('*.md'):
+            table = TAXONOMIES_TABLE.search(path.read_text(encoding='utf-8'))
+            if not table:
+                continue
+            line = TAGS_LINE.search(table.group(1))
+            if not line:
+                continue
+            for tag in QUOTED.findall(line.group(1)):
+                counts[tag] = counts.get(tag, 0) + 1
+    return counts
+
+
+def main() -> int:
+    listed = topic_tags()
+    used = content_tags()
+
+    uncovered = sorted(
+        ((count, tag) for tag, count in used.items() if tag not in listed),
+        reverse=True,
+    )
+    dead = sorted(listed - set(used))
+
+    if uncovered:
+        print('Tags no topic covers, so /topics/ never shows them:')
+        for count, tag in uncovered:
+            print(f'  {tag:24} {count} pages')
+        print('Add each to a [[extra.topics]] cluster in config.toml.\n')
+
+    if dead:
+        print('Topic tags no page carries, so they render as nothing:')
+        for tag in dead:
+            print(f'  {tag}')
+        print('Drop them from config.toml, or tag a page with them.\n')
+
+    if uncovered or dead:
+        return 1
+
+    print(f'  /topics/ covers all {len(used)} tags')
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/scripts/generate-md-pages.py
+++ b/scripts/generate-md-pages.py
@@ -48,6 +48,13 @@ def format_md_page(frontmatter: TFrontMatter, body: str, url: str, title: str) -
     if subtitle:
         output += f'*{subtitle}*\n\n'
 
+    # The canonical URL of the page this mirrors. These files exist to be read
+    # away from the site, by an agent or a plain curl, so the one thing they must
+    # carry is where they came from. It is also what keeps `url` honest: while
+    # nothing printed it, the caller could pass the English URL for a Spanish
+    # page and no output ever disagreed.
+    output += f'{url}\n\n'
+
     meta_parts = []
     if date:
         meta_parts.append(date)
@@ -69,8 +76,10 @@ def format_md_page(frontmatter: TFrontMatter, body: str, url: str, title: str) -
 def generate_index_md(section: TSection, files: List[TMdPage], base_url: str) -> str:
     """Generate an index.md for a section listing all files."""
     title = section.capitalize()
-    # Derive path prefix from base_url (e.g. '' or '/es')
-    path_prefix = base_url.replace('https://chemaclass.com', '')
+    # Path prefix ('' or '/es'), peeled off the origin rather than off a literal
+    # 'https://chemaclass.com': a second copy of the origin here silently stops
+    # matching the moment base_url in config.toml changes.
+    path_prefix = base_url[len(BASE_URL):]
 
     output = f'# {title}\n\n'
     output += f'[{base_url}/{section}/]({base_url}/{section}/)\n\n'
@@ -95,12 +104,14 @@ def generate_index_md(section: TSection, files: List[TMdPage], base_url: str) ->
     return output
 
 
-def process_markdown_file(filepath: Path, section: TSection, base_url: str) -> TMdPage:
+def process_markdown_file(filepath: Path, section: TSection, lang: TLang) -> TMdPage:
     """Process a single markdown file and generate .md version."""
     frontmatter, body = read_entry(filepath)
     title = require_title(frontmatter, filepath)
     slug = get_slug_from_filename(filepath.name)
-    url = entry_url(section, slug, base_url)
+    # entry_url takes the language explicitly: a Spanish page lives under /es/,
+    # and passing the origin alone gave all 175 of them the English URL.
+    url = entry_url(section, slug, es=(lang == 'es'))
 
     # Remove <!-- more --> markers
     body = re.sub(r'<!--\s*more\s*-->', '', body)
@@ -132,7 +143,7 @@ def main() -> None:
 
         for filepath in iter_section_files(section, translations=True):
             lang: TLang = 'es' if '.es.md' in filepath.name else 'en'
-            result = process_markdown_file(filepath, section, BASE_URL)
+            result = process_markdown_file(filepath, section, lang)
             per_lang[lang].append(result)
 
             prefix = PUBLIC_DIR / 'es' if lang == 'es' else PUBLIC_DIR

--- a/templates/music/index.html
+++ b/templates/music/index.html
@@ -7,7 +7,10 @@
 {% endblock %}
 
 {% block styles %}
-<link rel="stylesheet" href="{{ get_url(path='page.css') | safe }}">
+{# Via the macro, not a bare link: it also pulls in search.css, and base.html
+   renders the search dialog on every page. Hand-rolled, this shipped the dialog
+   markup with none of its styles. #}
+{{ macros::page_styles(css='page.css') }}
 {% endblock styles %}
 
 {% block content %}

--- a/templates/music/page.html
+++ b/templates/music/page.html
@@ -7,7 +7,7 @@
 {% endblock %}
 
 {% block styles %}
-<link rel="stylesheet" href="{{ get_url(path='page.css') | safe }}">
+{{ macros::page_styles(css='page.css') }}
 {% endblock styles %}
 
 {% block content %}

--- a/templates/partials/related-posts.html
+++ b/templates/partials/related-posts.html
@@ -4,8 +4,10 @@
   <div class="related-content__section">
     <h2 class="related-content__heading">{{ trans(key="related_posts", lang=lang) }}</h2>
     <div class="related-content__cards">
+      {# Front matter names the English file. Without lang, every Spanish post
+         sent the reader to the English version of its own related posts. #}
       {% for path in page.extra.related_posts %}
-        {% set related = get_page(path=path) %}
+        {% set related = get_page(path=path, lang=lang) %}
         <a href="{{ related.permalink }}" class="related-card">
           <span class="related-card__date">{% if lang == "es" %}{{ related.date | date(format="%d/%m/%Y") }}{% else %}{{ related.date | date(format="%b %d, %Y") }}{% endif %}</span>
           <h3 class="related-card__title">{{ related.title }}</h3>
@@ -23,10 +25,10 @@
     <h2 class="related-content__heading">{{ trans(key="related_readings", lang=lang) }}</h2>
     <div class="related-content__inline">
       {% for path in page.extra.related_readings %}
-        {% set related = get_page(path=path) %}
+        {% set related = get_page(path=path, lang=lang) %}
         <a href="{{ related.permalink }}" class="related-inline">
           <i class="fa-solid fa-book"></i>
-          <span>{{ related.title }}{% if related.extra.author %} <span class="related-inline__author">by {{ related.extra.author }}</span>{% endif %}</span>
+          <span>{{ related.title }}{% if related.extra.author %} <span class="related-inline__author">{{ trans(key="written_by", lang=lang) }} {{ related.extra.author }}</span>{% endif %}</span>
         </a>
       {% endfor %}
     </div>

--- a/templates/readings/post.html
+++ b/templates/readings/post.html
@@ -82,7 +82,7 @@
       <h1 class="blog-post__title">
         {{ page.title }}
         {% if page.extra.author %}
-          <small class="blog-post__author">by {{ page.extra.author }}</small>
+          <small class="blog-post__author">{{ trans(key="written_by", lang=lang) }} {{ page.extra.author }}</small>
         {% endif %}
       </h1>
 


### PR DESCRIPTION
Seven fixes from the site audit, each verified against a full production build in a clean worktree. One commit per finding.

## The Spanish site was quietly half English

Two separate defects, both on nearly every Spanish page.

`related-posts.html` called `get_page(path=path)` with no language. Front matter names the English file by convention, so **164 Spanish pages sent the reader to the English version of their own related posts**. `blog/index.html` already passed `lang=lang`; the partial now matches.

The author byline was hardcoded as `by` in two templates, while a `written_by` translation (`by` / `por`) already existed and was used by `helpers-preview.html`. That put English on **163 Spanish pages**.

Measured on the built output, before and after:

| | ES pages | before | after |
|---|---|---|---|
| related aside links to an English page | 164 | 164 | **0** |
| byline reads "by" | 163 | 163 | **0** |

English output is byte-identical: still 164 asides pointing at English pages, still 163 reading "by".

## /topics/ was hiding the biggest tag on the site

`templates/topics.html` groups tags into the `[[extra.topics]]` clusters in `config.toml`, and fails soft in both directions: a tag no cluster names is dropped from the page, a cluster naming a tag no page carries renders nothing. Both had happened.

**9 tags reached no cluster.** The largest was `ai` with 22 pages, more than any tag already listed, unreachable from `/topics/`. Added an "AI & Agents" cluster for `ai` and `agentic-coding`; filed `scrum`, `craftsmanship`, `software`, `engineering` and `modular` under Software Craft, `mindset` under Mind & Knowledge, `freedom` under Bitcoin & Economics.

**6 clusters named tags no page carries** (`encryption`, `finance`, `investing`, `money`, `professionalism`, `music`). Dropped.

Since both failures are silent, `scripts/check-topics.py` now fails the build on either, and `build.sh` runs it beside `check-icons.py`. Exercised by seeding each fault and confirming a non-zero exit.

## Two CSS selectors that matched nothing

`.pricing-card__badge` was nested under `.pricing-card--unavailable`, a modifier no template renders. The "Best value" badge on `/services/consulting/` inherited the h4 it sits in and read as plain heading text. Un-nested and restyled.

In `_post.scss`, `&:hover &-label` compiled to `.blog-post__nav-link-label`, but `post-navigation.html` emits `__nav-label`, without the `-link` infix. The prev/next hover colour had never applied.

## Music pages shipped the search dialog with none of its styles

`base.html` renders the site-search dialog on every page, but the music templates hand-rolled their stylesheet link instead of using `macros::page_styles`, which is what pulls in `search.css`. All 5 music pages were affected, the only ones on the site. Now zero pages carry the dialog without its stylesheet.

## Latent bugs with no symptom yet

`generate-md-pages.py` built the entry URL from the origin alone, so **all 172 Spanish `.md` mirrors claimed the English URL**. It survived because the `url` it computed was passed to `format_md_page` and then ignored: no output could disagree with it. Fixed both halves. `entry_url` now takes the language, and each mirror prints its canonical URL under the title. These files exist to be read away from the site, by an agent or a plain curl, so where they came from is the one thing they have to carry. The index generator also derived its path prefix by string-replacing a literal `https://chemaclass.com`, a second copy of the origin that would stop matching the moment `base_url` changed; it peels `BASE_URL` off instead.

One post spelled its revision date `updated_at`, which Zola does not read. The 2023 revision reached none of the four places that render `page.updated`: the atom feed, `article:modified_time`, schema.org `dateModified`, and the sitemap. Now it reaches all four.

## expand_preview is gone

122 readings set it. No template, script, stylesheet or JS has ever read it, and three docs still called it "the site default", so every new reading inherited a field that does nothing. Removed from content, template and docs. The reading template note now also points at `scripts/localize-reading-covers.py`, since `static_thumbnail` should be a local webp rather than the Amazon URL the old example showed.

## Verification

Full `./build.sh` in a clean git worktree, against the committed branch. 442 pages, both languages, minified, all post-build scripts green including the new check.

Every claim above was measured on that output: related-post language, byline language, `.md` canonical URLs (0 of 344 wrong), topics coverage, the compiled CSS selectors, `search.css` presence, the `updated` date reaching the feed and meta tags, and `expand_preview` absent from every generated file.

`zola check` reports 23 broken links, all external third-party 403/404s, all present on `main` before this branch.
